### PR TITLE
Cleanup of compiler warnings.

### DIFF
--- a/openHAB/ChartUITableViewCell.m
+++ b/openHAB/ChartUITableViewCell.m
@@ -28,14 +28,16 @@
     }
     NSLog(@"Chart url %@", chartUrl);
     if (widget.image == nil) {
-        [self.widgetImage setImageWithURL:[NSURL URLWithString:chartUrl] placeholderImage:nil options:SDWebImageCacheMemoryOnly completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
-//        NSLog(@"Image load complete %f %f", self.widgetImage.image.size.width, self.widgetImage.image.size.height);
-            widget.image = self.widgetImage.image;
-            [self.widgetImage setFrame:self.contentView.frame];
-            if (self.delegate != nil) {
-                [self.delegate didLoadImage];
-            }
-        }];
+        [self.widgetImage sd_setImageWithURL:[NSURL URLWithString:chartUrl]
+                            placeholderImage:nil
+                                     options:SDWebImageCacheMemoryOnly
+                                   completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
+                                       widget.image = self.widgetImage.image;
+                                       [self.widgetImage setFrame:self.contentView.frame];
+                                       if (self.delegate != nil) {
+                                           [self.delegate didLoadImage];
+                                       }
+                                   } ];
     } else {
         [self.widgetImage setImage:widget.image];
     }

--- a/openHAB/ImageUITableViewCell.m
+++ b/openHAB/ImageUITableViewCell.m
@@ -43,21 +43,27 @@ NSTimer *refreshTimer;
 - (void)loadImage
 {
     int random = arc4random() % 1000;
-    [widgetImage setImageWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@&random=%d", self.widget.url, random]] placeholderImage:nil options:SDWebImageCacheMemoryOnly completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
-        widget.image = self.widgetImage.image;
-        [widgetImage setFrame:self.contentView.frame];
-        if (self.delegate != nil) {
-            [self.delegate didLoadImage];
-        }
-    }];
+    [widgetImage sd_setImageWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@&random=%d", self.widget.url, random]]
+                   placeholderImage:nil
+                            options:SDWebImageCacheMemoryOnly
+                          completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
+                                        widget.image = self.widgetImage.image;
+                                        [widgetImage setFrame:self.contentView.frame];
+                                        if (self.delegate != nil) {
+                                            [self.delegate didLoadImage];
+                                        }
+                                    }];
+
 }
 
 - (void)refreshImage:(NSTimer *)timer
 {
     int random = arc4random() % 1000;
-    [widgetImage setImageWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@&random=%d", self.widget.url, random]] placeholderImage:self.widgetImage.image options:SDWebImageCacheMemoryOnly completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
-        widget.image = self.widgetImage.image;
-    }];
+    [widgetImage sd_setImageWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@&random=%d", self.widget.url, random]]
+                   placeholderImage:self.widgetImage.image
+                            options:SDWebImageCacheMemoryOnly
+                          completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
+                                    widget.image = self.widgetImage.image;     }];
 }
 
 - (void)willMoveToWindow:(UIWindow *)newWindow

--- a/openHAB/OpenHABAppDelegate.m
+++ b/openHAB/OpenHABAppDelegate.m
@@ -53,7 +53,7 @@ AVAudioPlayer *player;
 //    AudioSessionInitialize(NULL, NULL, nil , nil);
 //    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error: nil];
     [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient withOptions:AVAudioSessionCategoryOptionDuckOthers error:nil];
-    UInt32 doSetProperty = 1;
+    //UInt32 doSetProperty = 1;
 //    AudioSessionSetProperty(kAudioSessionProperty_OverrideCategoryMixWithOthers, sizeof(doSetProperty), &doSetProperty);
 //    [[AVAudioSession sharedInstance] setActive: YES error: nil];
     NSLog(@"didFinishLaunchingWithOptions ended");

--- a/openHAB/OpenHABInfoViewController.m
+++ b/openHAB/OpenHABInfoViewController.m
@@ -36,7 +36,7 @@
     id tracker = [[GAI sharedInstance] defaultTracker];
     [tracker set:kGAIScreenName
            value:@"OpenHABInfoViewController"];
-    [tracker send:[[GAIDictionaryBuilder createAppView] build]];
+    [tracker send:[[GAIDictionaryBuilder createScreenView] build]];
 }
 
 - (void)didReceiveMemoryWarning

--- a/openHAB/OpenHABLegalViewController.m
+++ b/openHAB/OpenHABLegalViewController.m
@@ -33,7 +33,7 @@
     id tracker = [[GAI sharedInstance] defaultTracker];
     [tracker set:kGAIScreenName
            value:@"OpenHABLegalViewController"];
-    [tracker send:[[GAIDictionaryBuilder createAppView] build]];
+    [tracker send:[[GAIDictionaryBuilder createScreenView] build]];
 }
 
 - (void)didReceiveMemoryWarning

--- a/openHAB/OpenHABSelectSitemapViewController.m
+++ b/openHAB/OpenHABSelectSitemapViewController.m
@@ -64,7 +64,7 @@
     id tracker = [[GAI sharedInstance] defaultTracker];
     [tracker set:kGAIScreenName
            value:@"OpenHABSelectSitemapViewController"];
-    [tracker send:[[GAIDictionaryBuilder createAppView] build]];
+    [tracker send:[[GAIDictionaryBuilder createScreenView] build]];
     NSString *sitemapsUrlString = [NSString stringWithFormat:@"%@/rest/sitemaps", self.openHABRootUrl];
     NSURL *sitemapsUrl = [[NSURL alloc] initWithString:sitemapsUrlString];
     NSMutableURLRequest *sitemapsRequest = [NSMutableURLRequest requestWithURL:sitemapsUrl];
@@ -156,10 +156,14 @@
     if (sitemap.icon != nil) {
         NSString *iconUrlString = [NSString stringWithFormat:@"%@/images/%@.png", self.openHABRootUrl, sitemap.icon];
         NSLog(@"icon url = %@", iconUrlString);
-        [cell.imageView setImageWithURL:[NSURL URLWithString:iconUrlString] placeholderImage:[UIImage imageNamed:@"blankicon.png"] options:0];
+        [cell.imageView sd_setImageWithURL:[NSURL URLWithString:iconUrlString]
+                          placeholderImage:[UIImage imageNamed:@"blankicon.png"]
+                                   options:0];
     } else {
         NSString *iconUrlString = [NSString stringWithFormat:@"%@/images/openhab.png", self.openHABRootUrl];
-        [cell.imageView setImageWithURL:[NSURL URLWithString:iconUrlString] placeholderImage:[UIImage imageNamed:@"blankicon.png"] options:0];
+        [cell.imageView sd_setImageWithURL:[NSURL URLWithString:iconUrlString]
+                          placeholderImage:[UIImage imageNamed:@"blankicon.png"]
+                                   options:0];
     }
     return cell;
 }

--- a/openHAB/OpenHABSelectionTableViewController.m
+++ b/openHAB/OpenHABSelectionTableViewController.m
@@ -29,7 +29,7 @@
 {
     [super viewDidLoad];
     
-    NSLog(@"I have %d mappings", [mappings count]);
+    NSLog(@"I have %lu mappings", (unsigned long)[mappings count]);
     
     // Uncomment the following line to preserve selection between presentations.
     // self.clearsSelectionOnViewWillAppear = NO;
@@ -78,7 +78,7 @@
 {
     NSLog(@"Selected mapping %ld", (long)indexPath.row);
     if (self.delegate != nil) {
-        [self.delegate didSelectWidgetMapping:indexPath.row];
+        [self.delegate didSelectWidgetMapping:(int)indexPath.row];
     }
     [self.navigationController popViewControllerAnimated:YES];
 }

--- a/openHAB/OpenHABSettingsViewController.m
+++ b/openHAB/OpenHABSettingsViewController.m
@@ -54,7 +54,7 @@
     id tracker = [[GAI sharedInstance] defaultTracker];
     [tracker set:kGAIScreenName
            value:@"OpenHABSettingsViewController"];
-    [tracker send:[[GAIDictionaryBuilder createAppView] build]];
+    [tracker send:[[GAIDictionaryBuilder createScreenView] build]];
     [settingsTableView deselectRowAtIndexPath:self.tableView.indexPathForSelectedRow
                                   animated:YES];
 }

--- a/openHAB/OpenHABTracker.m
+++ b/openHAB/OpenHABTracker.m
@@ -201,7 +201,7 @@
 {
     Reachability *networkReach = [Reachability reachabilityForInternetConnection];
     NetworkStatus networkReachabilityStatus = [networkReach currentReachabilityStatus];
-    NSLog(@"Network status = %d", networkReachabilityStatus);
+    NSLog(@"Network status = %ld", (long)networkReachabilityStatus);
     if (networkReachabilityStatus == ReachableViaWiFi || networkReachabilityStatus == ReachableViaWWAN) {
         return YES;
     }

--- a/openHAB/OpenHABViewController.m
+++ b/openHAB/OpenHABViewController.m
@@ -124,7 +124,7 @@
     id gaiTracker = [[GAI sharedInstance] defaultTracker];
     [gaiTracker set:kGAIScreenName
            value:@"OpenHABViewController"];
-    [gaiTracker send:[[GAIDictionaryBuilder createAppView] build]];
+    [gaiTracker send:[[GAIDictionaryBuilder createScreenView] build]];
     // Load settings into local properties
     [self loadSettings];
     // Set authentication parameters to SDImage
@@ -441,8 +441,6 @@
         NSLog(@"This is an openHAB 2.X");
         [[self appData] setOpenHABVersion:2];
         [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
-        NSData *response = (NSData*)responseObject;
-        NSError *error;
         [self selectSitemap];
     } failure:^(AFHTTPRequestOperation *operation, NSError *error){
         NSLog(@"This is an openHAB 1.X");
@@ -509,6 +507,8 @@
 
 - (void)loadPage:(Boolean)longPolling
 {
+    __weak typeof(self) weakSelf = self;
+    __weak typeof(currentPage) weakCurrentPage = currentPage;
     if (self.pageUrl == nil) {
         return;
     }
@@ -559,10 +559,9 @@
     [currentPageOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
         NSLog(@"Page loaded with success");
         NSDictionary *headers = operation.response.allHeaderFields;
-//        NSLog(@"%@", headers);
         if ([headers objectForKey:@"X-Atmosphere-tracking-id"] != nil) {
             NSLog(@"Found X-Atmosphere-tracking-id: %@", [headers objectForKey:@"X-Atmosphere-tracking-id"]);
-            self.atmosphereTrackingId = [headers objectForKey:@"X-Atmosphere-tracking-id"];
+            weakSelf.atmosphereTrackingId = [headers objectForKey:@"X-Atmosphere-tracking-id"];
         }
         NSData *response = (NSData*)responseObject;
         NSError *error;
@@ -581,32 +580,32 @@
         } else {
             currentPage = [[OpenHABSitemapPage alloc] initWithDictionary:responseObject];
         }
-        [currentPage setDelegate:self];
-        [self.widgetTableView reloadData];
+        [weakCurrentPage setDelegate:weakSelf];
+        [weakSelf.widgetTableView reloadData];
         [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
-        [self.refreshControl endRefreshing];
-        self.navigationItem.title = [self.currentPage.title componentsSeparatedByString:@"["][0];
+        [weakSelf.refreshControl endRefreshing];
+        weakSelf.navigationItem.title = [weakSelf.currentPage.title componentsSeparatedByString:@"["][0];
         if (longPolling == YES)
-            [self loadPage:NO];
+            [weakSelf loadPage:NO];
         else
-            [self loadPage:YES];
+            [weakSelf loadPage:YES];
     } failure:^(AFHTTPRequestOperation *operation, NSError *error){
         [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
         NSLog(@"Error:------>%@", [error description]);
         NSLog(@"error code %ld",(long)[operation.response statusCode]);
-        self.atmosphereTrackingId = nil;
+        weakSelf.atmosphereTrackingId = nil;
         if (error.code == -1001 && longPolling) {
             NSLog(@"Timeout, restarting requests");
-            [self loadPage:NO];
+            [weakSelf loadPage:NO];
         } else if (error.code == -999) {
             // Request was cancelled
             NSLog(@"Request was cancelled");
         } else {
             // Error
             if (error.code == -1012) {
-                [TSMessage showNotificationInViewController:self.navigationController title:@"Error" subtitle:@"SSL Certificate Error" image:nil type:TSMessageNotificationTypeError duration:5.0 callback:nil buttonTitle:nil buttonCallback:nil atPosition:TSMessageNotificationPositionBottom canBeDismissedByUser:YES];
+                [TSMessage showNotificationInViewController:weakSelf.navigationController title:@"Error" subtitle:@"SSL Certificate Error" image:nil type:TSMessageNotificationTypeError duration:5.0 callback:nil buttonTitle:nil buttonCallback:nil atPosition:TSMessageNotificationPositionBottom canBeDismissedByUser:YES];
             } else {
-                [TSMessage showNotificationInViewController:self.navigationController title:@"Error" subtitle:[error localizedDescription] image:nil type:TSMessageNotificationTypeError duration:5.0 callback:nil buttonTitle:nil buttonCallback:nil atPosition:TSMessageNotificationPositionBottom canBeDismissedByUser:YES];
+                [TSMessage showNotificationInViewController:weakSelf.navigationController title:@"Error" subtitle:[error localizedDescription] image:nil type:TSMessageNotificationTypeError duration:5.0 callback:nil buttonTitle:nil buttonCallback:nil atPosition:TSMessageNotificationPositionBottom canBeDismissedByUser:YES];
             }
             NSLog(@"Request failed: %@", [error localizedDescription]);
         }

--- a/openHAB/OpenHABWidget.m
+++ b/openHAB/OpenHABWidget.m
@@ -13,7 +13,7 @@
 #import "OpenHABWidgetMapping.h"
 
 @implementation OpenHABWidget
-@synthesize widgetId, label, icon, type, url, period, minValue, maxValue, step, refresh, height, isLeaf, iconColor, labelcolor, valuecolor, item, linkedPage, text, mappings, delegate, image;
+@synthesize widgetId, label, icon, type, url, period, minValue, maxValue, step, refresh, height, isLeaf, iconColor, labelcolor, valuecolor, item, linkedPage, text, mappings, delegate, image, service;
 
 - (OpenHABWidget *) initWithXML:(GDataXMLElement *)xmlElement
 {

--- a/openHAB/SegmentedUITableViewCell.m
+++ b/openHAB/SegmentedUITableViewCell.m
@@ -43,7 +43,7 @@
 -(void) pickOne:(id)sender
 {
     UISegmentedControl *segmentedControl = (UISegmentedControl *)sender;
-    NSLog(@"Segment pressed %d", [segmentedControl selectedSegmentIndex]);
+    NSLog(@"Segment pressed %ld", (long)[segmentedControl selectedSegmentIndex]);
     if (self.widget.mappings != nil) {
         OpenHABWidgetMapping *mapping = [self.widget.mappings objectAtIndex:[segmentedControl selectedSegmentIndex]];
         [self.widget sendCommand:mapping.command];

--- a/openHAB/SetpointUITableViewCell.m
+++ b/openHAB/SetpointUITableViewCell.m
@@ -44,7 +44,7 @@
 -(void) pickOne:(id)sender
 {
     UISegmentedControl *segmentedControl = (UISegmentedControl *)sender;
-    NSLog(@"Setpoint pressed %d", [segmentedControl selectedSegmentIndex]);
+    NSLog(@"Setpoint pressed %ld", (long)[segmentedControl selectedSegmentIndex]);
     // Deselect segment in the middle
     if ([segmentedControl selectedSegmentIndex] == 1) {
         [self.widgetSegmentedControl setSelectedSegmentIndex:-1];


### PR DESCRIPTION
Cleanup of compiler warnings, mostly due to deprecated framework methods. Removed commented code encountered.

Touch tested only, could use additional testing. 
