### PR TITLE
Ignore Pods directory and xcuserdata, added xcworkspace and Podfile.lock to repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Pods
+xcuserdata

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,0 +1,58 @@
+PODS:
+  - AFNetworking (2.6.3):
+    - AFNetworking/NSURLConnection (= 2.6.3)
+    - AFNetworking/NSURLSession (= 2.6.3)
+    - AFNetworking/Reachability (= 2.6.3)
+    - AFNetworking/Security (= 2.6.3)
+    - AFNetworking/Serialization (= 2.6.3)
+    - AFNetworking/UIKit (= 2.6.3)
+  - AFNetworking/NSURLConnection (2.6.3):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/NSURLSession (2.6.3):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/Reachability (2.6.3)
+  - AFNetworking/Security (2.6.3)
+  - AFNetworking/Serialization (2.6.3)
+  - AFNetworking/UIKit (2.6.3):
+    - AFNetworking/NSURLConnection
+    - AFNetworking/NSURLSession
+  - CrittercismSDK (5.4.11)
+  - FastSocket (1.3)
+  - GDataXML-HTML (1.3.0)
+  - GoogleAnalytics-iOS-SDK (3.12):
+    - GoogleAnalytics-iOS-SDK/Core (= 3.12)
+  - GoogleAnalytics-iOS-SDK/Core (3.12)
+  - HexColors (2.2.1)
+  - NKOColorPickerView (0.5)
+  - SDWebImage (3.7.3):
+    - SDWebImage/Core (= 3.7.3)
+  - SDWebImage/Core (3.7.3)
+  - TSMessages (0.9.12):
+    - HexColors (~> 2.2.0)
+
+DEPENDENCIES:
+  - AFNetworking (~> 2.6.0)
+  - CrittercismSDK (~> 5.4.0)
+  - FastSocket (~> 1.3)
+  - GDataXML-HTML (~> 1.3.0)
+  - GoogleAnalytics-iOS-SDK (~> 3.12)
+  - NKOColorPickerView (~> 0.5)
+  - SDWebImage (~> 3.7.3)
+  - TSMessages (~> 0.9.12)
+
+SPEC CHECKSUMS:
+  AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
+  CrittercismSDK: bea34b91a42eebc03eac6effa81b4d761b12ed3f
+  FastSocket: 0fa2716071517078d67ead1378d34af443bd54c4
+  GDataXML-HTML: 7adc03668cab35c288f1dbb8929a179f0fece898
+  GoogleAnalytics-iOS-SDK: 13241762fa4aea845eb75bef6c0da3427a26e7b3
+  HexColors: abfd172e329dab59888614ccba6f216cec59289d
+  NKOColorPickerView: 895ca86fe5bd16f27c311ce8f5888907efee29ad
+  SDWebImage: 1d2b1a1efda1ade1b00b6f8498865f8ddedc8a84
+  TSMessages: c8cc7b80f2a833af533872cd02010cac061532cc
+
+COCOAPODS: 0.39.0

--- a/openHAB.xcworkspace/contents.xcworkspacedata
+++ b/openHAB.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:openHAB.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
I think you should have a “clean” repo after cloning and “pod install”-ing, which is why I added `xcuserdata` to .gitignore and added the xcworkspace to the repo.


Whether the `Pods` directory should be checked in is up to taste, so I didn’t do that yet.
I did check in the Podfile.lock, though:

> Whether or not you check in the Pods directory, the Podfile and Podfile.lock should always be kept under version control.

(This is a quote from the [CocoaPods guide](https://guides.cocoapods.org/using/using-cocoapods.html))