### PR TITLE
Fix for deprecation warning for unarchiveTopLevelObjectWithData

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Util/ServerCertificateManager.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/ServerCertificateManager.swift
@@ -44,7 +44,7 @@ public class ServerCertificateManager: ServerTrustManager, ServerTrustEvaluating
     weak var delegate: ServerCertificateManagerDelegate?
     // ignoreSSL is a synonym for allowInvalidCertificates, ignoreCertificates
     public var ignoreSSL = false
-    public var trustedCertificates: [String: Any] = [:]
+    public var trustedCertificates: [String: Data] = [:]
 
     // Init a ServerCertificateManager and set ignore certificates setting
     public init(ignoreSSL: Bool) {
@@ -90,14 +90,17 @@ public class ServerCertificateManager: ServerTrustManager, ServerTrustEvaluating
     }
 
     func certificateData(forDomain domain: String) -> CFData? {
-        guard let certificateData = trustedCertificates[domain] as? Data else { return nil }
+        guard let certificateData = trustedCertificates[domain] else { return nil }
         return certificateData as CFData
     }
 
     func loadTrustedCertificates() {
         do {
             let rawdata = try Data(contentsOf: getPersistensePath())
-            if let unarchive = try NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(rawdata) as? [String: Any] {
+
+            // https://stackoverflow.com/questions/51487622/unarchive-array-with-nskeyedunarchiver-unarchivedobjectofclassfrom/52758898#52758898
+
+            if let unarchive = try? NSKeyedUnarchiver.unarchivedObject(ofClasses: [NSDictionary.self, NSData.self], from: rawdata) as? [String: Data] {
                 trustedCertificates = unarchive
             }
         } catch {

--- a/openHAB.xcodeproj/project.pbxproj
+++ b/openHAB.xcodeproj/project.pbxproj
@@ -1098,9 +1098,10 @@
 		DFB2621F18830A3600D3244D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				CLASSPREFIX = OpenHAB;
 				LastSwiftUpdateCheck = 1210;
-				LastUpgradeCheck = 1400;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "openHAB e.V.";
 				TargetAttributes = {
 					4D6470D22561F935007B03FC = {
@@ -1969,7 +1970,6 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1580410533;
-				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = PBAPXHRAM9;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "openHAB/openHAB-Prefix.pch";
@@ -2014,7 +2014,6 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1580410533;
-				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = PBAPXHRAM9;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "openHAB/openHAB-Prefix.pch";
@@ -2143,7 +2142,7 @@
 			repositoryURL = "https://github.com/onevcat/Kingfisher.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 7.0.0;
+				minimumVersion = 7.6.1;
 			};
 		};
 		93F8061927AE615D0035A6B0 /* XCRemoteSwiftPackageReference "Alamofire" */ = {

--- a/openHAB.xcodeproj/xcshareddata/xcschemes/openHAB.xcscheme
+++ b/openHAB.xcodeproj/xcshareddata/xcschemes/openHAB.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1430"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/openHAB.xcodeproj/xcshareddata/xcschemes/openHABTestsSwift.xcscheme
+++ b/openHAB.xcodeproj/xcshareddata/xcschemes/openHABTestsSwift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1430"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/openHAB.xcodeproj/xcshareddata/xcschemes/openHABUITests.xcscheme
+++ b/openHAB.xcodeproj/xcshareddata/xcschemes/openHABUITests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/openHAB.xcodeproj/xcshareddata/xcschemes/openHABWatch (Notification).xcscheme
+++ b/openHAB.xcodeproj/xcshareddata/xcschemes/openHABWatch (Notification).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1430"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/openHAB.xcodeproj/xcshareddata/xcschemes/openHABWatch.xcscheme
+++ b/openHAB.xcodeproj/xcshareddata/xcschemes/openHABWatch.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/openHAB.xcodeproj/xcshareddata/xcschemes/openHABWatchSwift (Complication).xcscheme
+++ b/openHAB.xcodeproj/xcshareddata/xcschemes/openHABWatchSwift (Complication).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1430"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/openHAB.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/openHAB.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -141,8 +141,8 @@
         "repositoryURL": "https://github.com/onevcat/Kingfisher.git",
         "state": {
           "branch": null,
-          "revision": "318e319998bf555c3e914d5c3adb6da05af86a32",
-          "version": "7.1.1"
+          "revision": "af4be924ad984cf4d16f4ae4df424e79a443d435",
+          "version": "7.6.2"
         }
       },
       {

--- a/openHABWatch Extension/openHABWatch Extension/external/AppMessageService.swift
+++ b/openHABWatch Extension/openHABWatch Extension/external/AppMessageService.swift
@@ -45,7 +45,7 @@ class AppMessageService: NSObject, WCSessionDelegate {
                 ObservableOpenHABDataObject.shared.ignoreSSL = ignoreSSL
             }
 
-            if let trustedCertificates = applicationContext["trustedCertificates"] as? [String: Any] {
+            if let trustedCertificates = applicationContext["trustedCertificates"] as? [String: Data] {
                 NetworkConnection.shared.serverCertificateManager.trustedCertificates = trustedCertificates
                 NetworkConnection.shared.serverCertificateManager.saveTrustedCertificates()
             }


### PR DESCRIPTION
`NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(rawdata) `is deprecateted since iOS 12.0
Replace it with `NSKeyedUnarchiver.unarchivedObject(ofClasses: [NSDictionary.self, NSData.self], from: rawdata) `
Removes a compiler warning