### PR TITLE
translate f7 underscores into iconify style dashes

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Util/Endpoint.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/Endpoint.swift
@@ -183,6 +183,7 @@ public extension Endpoint {
                 if source == "f7" {
                     source = "iconify"
                     set = "f7"
+                    icon = icon.replacingOccurrences(of: "_", with: "-")
                 }
                 if source == "if" || source == "iconify" {
                     queryItems = [URLQueryItem(name: "height", value: "64")]


### PR DESCRIPTION
f7 icons use underscores. When they're imported into iconify, the underscores became dashes.

When user actually specified f7:icon_name it should work without them having to know that we implemented it with iconify.

Alternatively users can use iconify:f7:icon-name with dashes.

If they had specified f7:icon-name that would still to work too

See also https://github.com/openhab/openhab-android/pull/3603