### PR TITLE
Change bundle display name to openHAB V1

### DIFF
--- a/openHAB/openHAB-Info.plist
+++ b/openHAB/openHAB-Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>${PRODUCT_NAME}</string>
+	<string>${PRODUCT_NAME} V1</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>${PRODUCT_NAME}</string>
+	<string>${PRODUCT_NAME} V1</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
see https://github.com/openhab/openhab-ios/issues/756#issuecomment-2136041863

This only changes the public facing display name in order to keep builds and maintenance easy.  So products , targets and other internal names still use `openHAB` 