### PR TITLE
Add 'none' option to version bumping. 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ on:
         type: choice
         description: 'Select version bump type:'
         options:
+        - none
         - patch
         - minor
         - major
@@ -41,6 +42,15 @@ jobs:
           ssh-private-key: |
             ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
 
+      - name: Set Fastlane Options
+        id: set_options
+        run: |
+          if [ "${{ github.event.inputs.bump_type }}" != "none" ]; then
+            echo "fastlane_options={ \"bump\": \"${{ github.event.inputs.bump_type }}\" }" >> $GITHUB_ENV
+          else
+            echo "fastlane_options={}" >> $GITHUB_ENV
+          fi
+
       - name: Deploy on TestFlight
         env:
           OH_CROWDIN_PROJECT_ID: openhab-ios
@@ -59,5 +69,5 @@ jobs:
         uses: maierj/fastlane-action@v3.1.0
         with:
           lane: beta
-          options: '{ "bump": "${{ github.event.inputs.bump_type }}" }'
+          options: ${{ steps.set_options.outputs.fastlane_options }}
           skip-tracking: true


### PR DESCRIPTION
This avoids long Test Flight reviews for incremental build releases.  This according to Apple:

"A review is only required for the first build of a version and subsequent builds may not need a full review. Testing can begin once a build is approved." .

https://developer.apple.com/help/app-store-connect/test-a-beta-version/testflight-overview/