### PR TITLE
Add 'none' option to version bumping.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ on:
         type: choice
         description: 'Select version bump type:'
         options:
+        - none
         - patch
         - minor
         - major

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -100,7 +100,7 @@ platform :ios do
 
         type = options[:bump]
 
-        if !options[:isfeaturebuild]
+        if !options[:isfeaturebuild] && type != 'none'
             increment_version_number_in_xcodeproj(
                 bump_type: type,
                 xcodeproj: 'openHAB.xcodeproj',


### PR DESCRIPTION
This avoids long Test Flight reviews for incremental build releases. This according to Apple:

"A review is only required for the first build of a version and subsequent builds may not need a full review. Testing can begin once a build is approved." .

https://developer.apple.com/help/app-store-connect/test-a-beta-version/testflight-overview/