### PR TITLE
Fixes notification crash, removes redundant call to RootView

### DIFF
--- a/openHAB/AppDelegate.swift
+++ b/openHAB/AppDelegate.swift
@@ -223,23 +223,25 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     }
 
     // this is called when clicking a notification while in the background
-    nonisolated func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) async {
-        var userInfo = response.notification.request.content.userInfo
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                didReceive response: UNNotificationResponse,
+                                withCompletionHandler completionHandler: @escaping () -> Void) {
         let actionIdentifier = response.actionIdentifier
-        logger.info("Notification clicked: action \(actionIdentifier) userInfo \(userInfo)")
-
-        if actionIdentifier != UNNotificationDismissActionIdentifier {
-            if actionIdentifier != UNNotificationDefaultActionIdentifier {
-                userInfo["actionIdentifier"] = actionIdentifier
-            }
-            NotificationCenter.default.post(
-                name: .openHABDidReceiveNotification,
-                object: nil,
-                userInfo: userInfo
-            )
-            let action = userInfo["actionIdentifier"] as? String ?? userInfo["on-click"] as? String
-            await notifyNotificationListeners(action: action)
+        var userInfo = response.notification.request.content.userInfo
+        print("Notification clicked: \(actionIdentifier)")
+        for (key, value) in userInfo {
+            print("userInfo: \(key) = \(value)")
         }
+        Task { @MainActor in
+            if actionIdentifier != UNNotificationDismissActionIdentifier {
+                if actionIdentifier != UNNotificationDefaultActionIdentifier {
+                    userInfo["actionIdentifier"] = actionIdentifier
+                }
+                let action = userInfo["actionIdentifier"] as? String ?? userInfo["on-click"] as? String
+                notifyNotificationListeners(action: action)
+            }
+        }
+        completionHandler()
     }
 
     private func displayNotification(message: String, action: String?) async {

--- a/openHAB/OpenHABRootViewController.swift
+++ b/openHAB/OpenHABRootViewController.swift
@@ -99,22 +99,6 @@ class OpenHABRootViewController: UIViewController {
         isDemoMode = Preferences.demomode
         switchToSavedView()
         setupTracker()
-        // check if we were launched with a notification
-        // ✅ Observe notifications (in-app or from AppDelegate)
-        NotificationCenter.default.addObserver(
-            forName: .openHABDidReceiveNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] notification in
-            guard let userInfo = notification.userInfo else { return }
-
-            // ✅ Extract action identifier (from button press or notification click) *before* entering the Task
-            let action = userInfo["actionIdentifier"] as? String ?? userInfo["on-click"] as? String
-
-            Task { @MainActor in
-                self?.handleNotification(action: action)
-            }
-        }
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
Something strange was interacting with IOS background threading using the "nonisolated" keyword, was tough to track down.   This fixes the crash.  I also noticed that this function was changed to call the rootview controller directly, but it was also still posting a notification, which the root view was observing (so everything was duplicated).  This was not part of the crash, but we should only be doing one or the other.   I removed the notification center logic so its only firing once now. 

We may need to revisit other  "nonisolated" functions that deal with the foreground/background lifecycle for potential crashes. 