### PR TITLE
Decode connection settings when loading stored preferences

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Util/Preferences.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/Preferences.swift
@@ -291,8 +291,8 @@ public extension Preferences {
         Preferences.defaultMainUIPath = stored["defaultMainUIPath"] as? String ?? ""
         Preferences.alwaysAllowWebRTC = stored["alwaysAllowWebRTC"] as? Bool ?? false
         Preferences.sitemapForWatch = stored["sitemapForWatch"] as? String ?? "watch"
-        Preferences.localConnectionConfig = stored["localConnectionConfig"] as? ConnectionConfiguration ?? ConnectionConfiguration.localDefault
-        Preferences.remoteConnectionConfig = stored["remoteConnectionConfig"] as? ConnectionConfiguration ?? ConnectionConfiguration.remoteDefault
+        Preferences.localConnectionConfig = (try? JSONDecoder().decode(ConnectionConfiguration.self, from: stored["localConnectionConfig"] as? Data ?? Data())) ?? ConnectionConfiguration.localDefault
+        Preferences.remoteConnectionConfig = (try? JSONDecoder().decode(ConnectionConfiguration.self, from: stored["remoteConnectionConfig"] as? Data ?? Data())) ?? ConnectionConfiguration.remoteDefault
         Preferences.sitemapForWatchLabel = stored["sitemapForWatchLabel"] as? String ?? "watch"
         Preferences.homeName = stored["homeName"] as? String ?? "Home"
         loadingStoredPreferences = false

--- a/openHAB/HomeSelectionView.swift
+++ b/openHAB/HomeSelectionView.swift
@@ -47,8 +47,6 @@ struct HomeSelectionView: View {
                             .foregroundStyle(.blue)
                     }
                     Text(homeName)
-                    // TODO: selection of name in list changes settings
-                    // TODO: options like remove, rename (or should we rename in settings?)
                     if Preferences.currentlyUsedSettings == home.uuidString, !showEditOptions {
                         Spacer()
                         Image(systemSymbol: .checkmark)
@@ -59,13 +57,12 @@ struct HomeSelectionView: View {
                 }
                 .contentShape(.interaction, Rectangle())
                 .onTapGesture {
+                    homeNameForAlert = homeName
+                    homeForAlert = home
+                    newHomeName = homeName
                     if !showEditOptions {
-                        Preferences.switchCurrentlyUsedSettings(to: home)
-                        dismiss()
+                        select(home: home)
                     } else {
-                        homeNameForAlert = homeName
-                        homeForAlert = home
-                        newHomeName = homeName
                         showingRenameHomeAlert.toggle()
                     }
                 }
@@ -176,6 +173,10 @@ struct HomeSelectionView: View {
         }
     }
 
+    private func select(home: UUID) {
+        Preferences.switchCurrentlyUsedSettings(to: home)
+    }
+
     private func loadHomesList() {
         homes = Preferences.listStoredPreferences()
     }
@@ -200,7 +201,6 @@ struct HomeSelectionView: View {
         } else {
             Preferences.renameHome(toRename, newHomeName: newName)
         }
-        loadHomesList()
     }
 
     private func addHome() {


### PR DESCRIPTION
also, to avoid a crash probably caused by asynchronous view hierarchy handling, don´t switch to root view immediately when choosing a different home