### PR TITLE
Remove redundancy in preferences, update watch when necessary

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Util/Preferences.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/Preferences.swift
@@ -22,48 +22,10 @@ public struct UserDefault<T: Sendable> {
 
     public var wrappedValue: T {
         get {
-            let preferenceValue = Preferences.sharedDefaults.object(forKey: key)
-            if let preferenceAsT = preferenceValue as? T {
-                os_log(
-                    "Preference value %{PUBLIC}@ is %{PUBLIC}@",
-                    log: .default,
-                    type: .debug,
-                    key,
-                    "\(preferenceAsT)"
-                )
-                return preferenceAsT
-            } else {
-                if let preferenceValue {
-                    os_log(
-                        "Preference value %{PUBLIC}@ was %{PUBLIC}@ but did not conform to %{PUBLIC}@. Replace with default value.",
-                        log: .default,
-                        type: .fault,
-                        key,
-                        "\(preferenceValue)",
-                        "\(T.self)"
-                    )
-                } else {
-                    os_log(
-                        "Preference value %{PUBLIC}@ was set for the first time. Using default value.",
-                        log: .default,
-                        type: .info,
-                        key
-                    )
-                }
-                let fallback = defaultValue
-                Preferences.sharedDefaults.set(fallback, forKey: key)
-                return fallback
-            }
+            Preferences.getPreference(key: key, defaultValue: defaultValue, encoder: { $0 }, decoder: { $0 as? T })
         }
         set {
-            os_log("Preference %{PUBLIC}@ will be changed to value %{PUBLIC}@", log: .default, type: .debug, key, "\(newValue)")
-            Preferences.sharedDefaults.set(newValue, forKey: key)
-            if store {
-                Preferences.storeCurrentPreferences(updatedKey: key, updatedValue: newValue)
-            }
-            DispatchQueue.main.async { [subject] in
-                subject.send(newValue)
-            }
+            Preferences.preferenceChanged(newValue: newValue, key: key, store: store, subject: subject) { $0 }
         }
     }
 
@@ -75,7 +37,7 @@ public struct UserDefault<T: Sendable> {
         self.key = key
         self.defaultValue = defaultValue
         self.store = store
-        let currentValue = Preferences.sharedDefaults.object(forKey: key) as? T ?? defaultValue
+        let currentValue = Preferences.getPreference(key: key, defaultValue: defaultValue, encoder: { $0 }, decoder: { $0 as? T })
         subject = CurrentValueSubject<T, Never>(currentValue)
     }
 }
@@ -87,25 +49,21 @@ public struct UserDefaultObject<T: Codable & Sendable> {
     private let store: Bool
     private let subject: CurrentValueSubject<T, Never>
 
+    private let objectDecoder: (Any) -> (T?) = {
+        guard let data = $0 as? Data else {
+            return nil
+        }
+        return try? JSONDecoder().decode(T.self, from: data)
+    }
+
+    private let objectEncoder: (T) -> (any Sendable)? = { try? JSONEncoder().encode($0) }
+
     public var wrappedValue: T {
         get {
-            guard let data = Preferences.sharedDefaults.data(forKey: key),
-                  let object = try? JSONDecoder().decode(T.self, from: data) else {
-                return defaultValue
-            }
-            return object
+            Preferences.getPreference(key: key, defaultValue: defaultValue, encoder: objectEncoder, decoder: objectDecoder)
         }
         set {
-            if let encoded = try? JSONEncoder().encode(newValue) {
-                Preferences.sharedDefaults.set(encoded, forKey: key)
-                if store {
-                    Preferences.storeCurrentPreferences(updatedKey: key, updatedValue: encoded)
-                }
-                // Relevant for Combine publication
-                DispatchQueue.main.async { [subject] in
-                    subject.send(newValue)
-                }
-            }
+            Preferences.preferenceChanged(newValue: newValue, key: key, store: store, subject: subject, converter: objectEncoder)
         }
     }
 
@@ -119,17 +77,29 @@ public struct UserDefaultObject<T: Codable & Sendable> {
         self.store = store
 
         // Combine publication
-        if let data = Preferences.sharedDefaults.data(forKey: key),
-           let object = try? JSONDecoder().decode(T.self, from: data) {
-            subject = CurrentValueSubject(object)
-        } else {
-            subject = CurrentValueSubject(defaultValue)
-        }
+        let currentValue = Preferences.getPreference(key: key, defaultValue: defaultValue, encoder: objectEncoder, decoder: objectDecoder)
+        subject = CurrentValueSubject(currentValue)
     }
 }
 
 @propertyWrapper @MainActor
 public struct UserDefaultURL {
+    private static let urlSanitizer: (String) -> (String?) = {
+        // Trim and validate the new URL
+        let trimmedUri = $0.removeTrailingSlashes().trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmedUri.isValidURL else {
+            return nil
+        }
+        return trimmedUri
+    }
+
+    private static let urlConverter: (Any) -> (String?) = {
+        guard let preferenceString = $0 as? String else {
+            return nil
+        }
+        return urlSanitizer(preferenceString)
+    }
+
     private let key: String
     private let defaultValue: String
     private let store: Bool
@@ -137,25 +107,10 @@ public struct UserDefaultURL {
 
     public var wrappedValue: String {
         get {
-            let storedValue = Preferences.sharedDefaults.string(forKey: key) ?? defaultValue
-            let trimmedUri = storedValue.removeTrailingSlashes().trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmedUri.isValidURL ? trimmedUri : defaultValue
+            Preferences.getPreference(key: key, defaultValue: defaultValue, encoder: UserDefaultURL.urlSanitizer, decoder: UserDefaultURL.urlConverter)
         }
         set {
-            Preferences.sharedDefaults.set(newValue, forKey: key)
-            if store {
-                Preferences.storeCurrentPreferences(updatedKey: key, updatedValue: newValue)
-            }
-            let defaultValue = defaultValue
-            // Trim and validate the new URL
-            let trimmedUri = newValue.removeTrailingSlashes().trimmingCharacters(in: .whitespacesAndNewlines)
-            DispatchQueue.main.async { [subject] in
-                if trimmedUri.isValidURL {
-                    subject.send(trimmedUri)
-                } else {
-                    subject.send(defaultValue)
-                }
-            }
+            Preferences.preferenceChanged(newValue: newValue, key: key, store: true, subject: subject, sanitize: UserDefaultURL.urlSanitizer) { $0 }
         }
     }
 
@@ -167,7 +122,7 @@ public struct UserDefaultURL {
         self.key = key
         self.defaultValue = defaultValue
         self.store = store
-        let currentValue = Preferences.sharedDefaults.string(forKey: key) ?? defaultValue
+        let currentValue = Preferences.getPreference(key: key, defaultValue: defaultValue, encoder: { $0 }, decoder: UserDefaultURL.urlConverter)
         subject = CurrentValueSubject<String, Never>(currentValue)
     }
 }
@@ -176,7 +131,7 @@ public struct UserDefaultURL {
 public enum Preferences {
     static let sharedDefaults = UserDefaults(suiteName: "group.org.openhab.app")!
 
-    // MARK: - Public Deprecated
+    // MARK: - Public Deprecated preferences
 
     @UserDefaultURL("localUrl", defaultValue: "", store: false) public static var localUrl: String
     @UserDefaultURL("remoteUrl", defaultValue: "https://myopenhab.org", store: false) public static var remoteUrl: String
@@ -185,7 +140,7 @@ public enum Preferences {
     @UserDefault("alwaysSendCreds", defaultValue: false, store: false) public static var alwaysSendCreds: Bool
     @UserDefault("ignoreSSL", defaultValue: false, store: false) public static var ignoreSSL: Bool
 
-    // MARK: - Public Home related
+    // MARK: - Public Home related preferences
 
     @UserDefaultURL("defaultView", defaultValue: "web") public static var defaultView: String
     @UserDefault("demomode", defaultValue: true) public static var demomode: Bool
@@ -201,15 +156,16 @@ public enum Preferences {
     @UserDefault("sitemapForWatchLabel", defaultValue: "watch") public static var sitemapForWatchLabel: String
     @UserDefault("homeName", defaultValue: "Home") public static var homeName: String
 
-    // MARK: - Public App related
+    // MARK: - Public App related preferences
 
     @UserDefault("sendCrashReports", defaultValue: false, store: false) public static var sendCrashReports: Bool
+
     @UserDefault("idleOff", defaultValue: false, store: false) public static var idleOff: Bool
 
     /// settings for different homes TODO come up with better name
     @UserDefault("storedPreferences", defaultValue: [:], store: false) public static var storedPreferences: [String: [String: any Sendable]]
 
-    // MARK: - Private
+    // MARK: - Private preferences
 
     /// the currently applied settings set from storedPreferences
     @UserDefault("currentlyUsedSettings", defaultValue: UUID().uuidString, store: false) public private(set) static var currentlyUsedSettings: String
@@ -220,6 +176,67 @@ public enum Preferences {
 
     private static var loadingStoredPreferences = false
 }
+
+// MARK: Retrieving preference from user defaults, reacting to preference change
+
+private extension Preferences {
+    static func getPreference<T>(key: String, defaultValue: T, encoder: (T) -> (some Sendable)?, decoder: (Any?) -> T?) -> T {
+        let preferenceValue = Preferences.sharedDefaults.object(forKey: key)
+        if let preferenceConverted = decoder(preferenceValue) {
+            os_log(
+                "Preference value %{PUBLIC}@ is %{PUBLIC}@",
+                log: .default,
+                type: .debug,
+                key,
+                "\(preferenceConverted)"
+            )
+            return preferenceConverted
+        } else {
+            if let preferenceValue {
+                os_log(
+                    "Preference value %{PUBLIC}@ was %{PUBLIC}@ but did not conform to %{PUBLIC}@. Replace with default value.",
+                    log: .default,
+                    type: .fault,
+                    key,
+                    "\(preferenceValue)",
+                    "\(T.self)"
+                )
+            } else {
+                os_log(
+                    "Preference value %{PUBLIC}@ was set for the first time. Using default value.",
+                    log: .default,
+                    type: .info,
+                    key
+                )
+            }
+            let fallback = defaultValue
+            Preferences.sharedDefaults.set(encoder(fallback), forKey: key)
+            return fallback
+        }
+    }
+
+    static func preferenceChanged<T>(newValue: T, key: String, store: Bool, subject: CurrentValueSubject<T, Never>, sanitize: (T) -> (T?) = { $0 }, converter: (T) -> (some Sendable)?) {
+        guard let sanitized = sanitize(newValue) else {
+            os_log("Preference %{PUBLIC}@ new value %{PUBLIC}@ could not be sanitized, will be ignored", log: .default, type: .debug, key, "\(newValue)")
+            return
+        }
+        let convertedValue = converter(sanitized)
+        guard convertedValue != nil else {
+            os_log("Preference %{PUBLIC}@ conversion of new value %{PUBLIC}@ failed, do not store.", log: .default, type: .debug, key, "\(sanitized)")
+            return
+        }
+        os_log("Preference %{PUBLIC}@ will be changed to value %{PUBLIC}@", log: .default, type: .debug, key, "\(newValue)")
+        Preferences.sharedDefaults.set(convertedValue, forKey: key)
+        if store {
+            Preferences.storeCurrentPreferences(updatedKey: key, updatedValue: convertedValue)
+        }
+        DispatchQueue.main.async { [subject] in
+            subject.send(sanitized)
+        }
+    }
+}
+
+// MARK: Multiple homes
 
 public extension Preferences {
     static func listStoredPreferences() -> [UUID] {
@@ -325,6 +342,8 @@ public extension Preferences {
     }
 }
 
+// MARK: Migration
+
 public extension Preferences {
     static func migrateUserDefaultsIfRequired() {
         guard !didMigrateToSharedDefaults else { return }
@@ -379,6 +398,8 @@ public extension Preferences {
         didMigrateToConnectionConfig = true
     }
 }
+
+// MARK: All connections
 
 public extension Preferences {
     static func getLowestPriorityOpenHABConnection() -> ConnectionConfiguration? {

--- a/OpenHABCore/Sources/OpenHABCore/Util/Preferences.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/Preferences.swift
@@ -87,7 +87,7 @@ public struct UserDefaultURL {
     private static let urlSanitizer: (String) -> (String?) = {
         // Trim and validate the new URL
         let trimmedUri = $0.removeTrailingSlashes().trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmedUri.isValidURL else {
+        guard trimmedUri.isValidURL || trimmedUri.isEmpty else { // empty is the default for localUrl
             return nil
         }
         return trimmedUri
@@ -194,7 +194,7 @@ private extension Preferences {
         } else {
             if let preferenceValue {
                 os_log(
-                    "Preference value %{PUBLIC}@ was %{PUBLIC}@ but did not conform to %{PUBLIC}@. Replace with default value.",
+                    "Preference value %{PUBLIC}@ was \"%{PUBLIC}@\" but did not conform to %{PUBLIC}@. Replace with default value.",
                     log: .default,
                     type: .fault,
                     key,
@@ -217,7 +217,7 @@ private extension Preferences {
 
     static func preferenceChanged<T>(newValue: T, key: String, store: Bool, subject: CurrentValueSubject<T, Never>, sanitize: (T) -> (T?) = { $0 }, converter: (T) -> (some Sendable)?) {
         guard let sanitized = sanitize(newValue) else {
-            os_log("Preference %{PUBLIC}@ new value %{PUBLIC}@ could not be sanitized, will be ignored", log: .default, type: .debug, key, "\(newValue)")
+            os_log("Preference %{PUBLIC}@ new value \"%{PUBLIC}@\" could not be sanitized, will be ignored", log: .default, type: .debug, key, "\(newValue)")
             return
         }
         let convertedValue = converter(sanitized)

--- a/openHAB/AppDelegate.swift
+++ b/openHAB/AppDelegate.swift
@@ -56,6 +56,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     let audioPlayer = AudioPlayerActor()
     var window: UIWindow?
 
+    private var crashlyticsSubscriber: AnyCancellable?
+
     // Delegate Requests from the Watch to the WatchMessageService
     var session: WCSession? {
         didSet {
@@ -112,7 +114,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // init Firebase crash reporting
         FirebaseApp.configure()
         FirebaseApp.app()?.isDataCollectionDefaultEnabled = false
-        Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(Preferences.sendCrashReports)
+        crashlyticsSubscriber = Preferences.$sendCrashReports.sink { [weak self] in
+            // TODO: is this called once we setup this subscriber? Otherwise we need to manually invoke it for setting up
+            Crashlytics.crashlytics().setCrashlyticsCollectionEnabled($0)
+            self?.logger.debug("setCrashlyticsCollectionEnabled to \($0)")
+        }
         Messaging.messaging().delegate = self
     }
 

--- a/openHAB/AppDelegate.swift
+++ b/openHAB/AppDelegate.swift
@@ -10,6 +10,7 @@
 // SPDX-License-Identifier: EPL-2.0
 
 import AVFoundation
+import Combine
 import Firebase
 import FirebaseMessaging
 import Kingfisher
@@ -59,9 +60,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var session: WCSession? {
         didSet {
             if let session {
-                session.delegate = WatchMessageService.singleton
+                let watchMessageService = WatchMessageService.singleton
+                session.delegate = watchMessageService
                 session.activate()
                 os_log("Paired watch %{PUBLIC}@, watch app installed %{PUBLIC}@", log: .watch, type: .info, "\(session.isPaired)", "\(session.isWatchAppInstalled)")
+                watchMessageService.subscribeToPreferences()
             }
         }
     }

--- a/openHAB/DrawerView.swift
+++ b/openHAB/DrawerView.swift
@@ -147,7 +147,6 @@ struct DrawerView: View {
                             Preferences.sitemapForWatch = sitemap.name
                             Preferences.sitemapForWatchLabel = sitemap.label
                         }
-                        WatchMessageService.singleton.syncPreferencesToWatch()
                     }
                 }
             }

--- a/openHAB/HomeSelectionView.swift
+++ b/openHAB/HomeSelectionView.swift
@@ -175,7 +175,6 @@ struct HomeSelectionView: View {
 
     private func select(home: UUID) {
         Preferences.switchCurrentlyUsedSettings(to: home)
-        WatchMessageService.singleton.syncPreferencesToWatch()
     }
 
     private func loadHomesList() {
@@ -206,7 +205,6 @@ struct HomeSelectionView: View {
 
     private func addHome() {
         Preferences.createAndLoadNewStoredSettings(homeName: newHomeName)
-        WatchMessageService.singleton.syncPreferencesToWatch()
         loadHomesList()
     }
 }

--- a/openHAB/HomeSelectionView.swift
+++ b/openHAB/HomeSelectionView.swift
@@ -175,6 +175,7 @@ struct HomeSelectionView: View {
 
     private func select(home: UUID) {
         Preferences.switchCurrentlyUsedSettings(to: home)
+        WatchMessageService.singleton.syncPreferencesToWatch()
     }
 
     private func loadHomesList() {
@@ -205,6 +206,7 @@ struct HomeSelectionView: View {
 
     private func addHome() {
         Preferences.createAndLoadNewStoredSettings(homeName: newHomeName)
+        WatchMessageService.singleton.syncPreferencesToWatch()
         loadHomesList()
     }
 }

--- a/openHAB/OpenHABRootViewController.swift
+++ b/openHAB/OpenHABRootViewController.swift
@@ -68,7 +68,6 @@ class OpenHABRootViewController: UIViewController {
             alertController.addAction(
                 UIAlertAction(title: NSLocalizedString("activate", comment: ""), style: .default) { _ in
                     Preferences.sendCrashReports = true
-                    Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(true)
                     Crashlytics.crashlytics().sendUnsentReports()
                 }
             )

--- a/openHAB/SettingsView/SettingsView.swift
+++ b/openHAB/SettingsView/SettingsView.swift
@@ -161,8 +161,6 @@ struct SettingsView: View {
         Preferences.sitemapForWatchLabel = sitemaps.first { $0.name == settingsSitemapForWatch }?.label ?? "unknown"
         Preferences.localConnectionConfig = settingsLocalConnectionConfiguration
         Preferences.remoteConnectionConfig = settingsRemoteConnectionConfiguration
-        Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(settingsSendCrashReports)
-        logger.debug("setCrashlyticsCollectionEnabled to \(settingsSendCrashReports)")
     }
 }
 

--- a/openHAB/SettingsView/SettingsView.swift
+++ b/openHAB/SettingsView/SettingsView.swift
@@ -161,7 +161,6 @@ struct SettingsView: View {
         Preferences.sitemapForWatchLabel = sitemaps.first { $0.name == settingsSitemapForWatch }?.label ?? "unknown"
         Preferences.localConnectionConfig = settingsLocalConnectionConfiguration
         Preferences.remoteConnectionConfig = settingsRemoteConnectionConfiguration
-        WatchMessageService.singleton.syncPreferencesToWatch()
         Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(settingsSendCrashReports)
         logger.debug("setCrashlyticsCollectionEnabled to \(settingsSendCrashReports)")
     }

--- a/openHAB/WatchMessageService.swift
+++ b/openHAB/WatchMessageService.swift
@@ -9,6 +9,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0
 
+import Combine
 import Foundation
 import OpenHABCore
 import os.log
@@ -24,6 +25,8 @@ class WatchMessageService: NSObject, WCSessionDelegate {
 
     private var cachedWatchPreferences: [String: Data] = [:]
     private let lock = NSLock()
+
+    private var preferencesSubscription: AnyCancellable?
 
     // This method gets called when the watch requests the data
     // ⚠️ This is called off the main thread. Do NOT touch @MainActor stuff.
@@ -54,6 +57,43 @@ class WatchMessageService: NSObject, WCSessionDelegate {
     }
 
     // MARK: - Sync Preferences
+
+    @MainActor
+    public func subscribeToPreferences() {
+        let currentlyUsedSettings: AnyPublisher<any Sendable, Never> = Preferences.$currentlyUsedSettings
+            .map { $0 as any Sendable }
+            .eraseToAnyPublisher()
+        let watchRelatedSettingsPart1: AnyPublisher<any Sendable, Never> =
+            currentlyUsedSettings
+                .merge(
+                    with:
+                    Preferences.$localUrl.map { $0 as any Sendable }.eraseToAnyPublisher(),
+                    Preferences.$remoteUrl.map { $0 as any Sendable }.eraseToAnyPublisher(),
+                    Preferences.$username.map { $0 as any Sendable }.eraseToAnyPublisher(),
+                    Preferences.$password.map { $0 as any Sendable }.eraseToAnyPublisher(),
+                    Preferences.$alwaysSendCreds.map { $0 as any Sendable }.eraseToAnyPublisher(),
+                    Preferences.$defaultSitemap.map { $0 as any Sendable }.eraseToAnyPublisher(),
+                    Preferences.$ignoreSSL.map { $0 as any Sendable }.eraseToAnyPublisher()
+                )
+                .eraseToAnyPublisher()
+        let watchRelatedSettingsPart2: AnyPublisher<any Sendable, Never> = watchRelatedSettingsPart1
+            .merge(
+                with:
+                Preferences.$sitemapForWatch.map { $0 as any Sendable }.eraseToAnyPublisher(),
+                Preferences.$sitemapForWatchLabel.map { $0 as any Sendable }.eraseToAnyPublisher(),
+                Preferences.$iconType.map { $0 as any Sendable }.eraseToAnyPublisher(),
+                Preferences.$demomode.map { $0 as any Sendable }.eraseToAnyPublisher(),
+                Preferences.$localConnectionConfig.map { $0 as any Sendable }.eraseToAnyPublisher(),
+                Preferences.$localConnectionConfig.map { $0 as any Sendable }.eraseToAnyPublisher()
+            )
+            .eraseToAnyPublisher()
+
+        preferencesSubscription = watchRelatedSettingsPart2
+            .debounce(for: .seconds(1), scheduler: RunLoop.main)
+            .sink { _ in } receiveValue: { _ in
+                self.syncPreferencesToWatch()
+            }
+    }
 
     @MainActor
     public func syncPreferencesToWatch() {

--- a/openHAB/WatchMessageService.swift
+++ b/openHAB/WatchMessageService.swift
@@ -63,22 +63,10 @@ class WatchMessageService: NSObject, WCSessionDelegate {
         let currentlyUsedSettings: AnyPublisher<any Sendable, Never> = Preferences.$currentlyUsedSettings
             .map { $0 as any Sendable }
             .eraseToAnyPublisher()
-        let watchRelatedSettingsPart1: AnyPublisher<any Sendable, Never> =
-            currentlyUsedSettings
-                .merge(
-                    with:
-                    Preferences.$localUrl.map { $0 as any Sendable }.eraseToAnyPublisher(),
-                    Preferences.$remoteUrl.map { $0 as any Sendable }.eraseToAnyPublisher(),
-                    Preferences.$username.map { $0 as any Sendable }.eraseToAnyPublisher(),
-                    Preferences.$password.map { $0 as any Sendable }.eraseToAnyPublisher(),
-                    Preferences.$alwaysSendCreds.map { $0 as any Sendable }.eraseToAnyPublisher(),
-                    Preferences.$defaultSitemap.map { $0 as any Sendable }.eraseToAnyPublisher(),
-                    Preferences.$ignoreSSL.map { $0 as any Sendable }.eraseToAnyPublisher()
-                )
-                .eraseToAnyPublisher()
-        let watchRelatedSettingsPart2: AnyPublisher<any Sendable, Never> = watchRelatedSettingsPart1
+        let watchRelatedSettings: AnyPublisher<any Sendable, Never> = currentlyUsedSettings
             .merge(
                 with:
+                Preferences.$defaultSitemap.map { $0 as any Sendable }.eraseToAnyPublisher(),
                 Preferences.$sitemapForWatch.map { $0 as any Sendable }.eraseToAnyPublisher(),
                 Preferences.$sitemapForWatchLabel.map { $0 as any Sendable }.eraseToAnyPublisher(),
                 Preferences.$iconType.map { $0 as any Sendable }.eraseToAnyPublisher(),
@@ -88,7 +76,7 @@ class WatchMessageService: NSObject, WCSessionDelegate {
             )
             .eraseToAnyPublisher()
 
-        preferencesSubscription = watchRelatedSettingsPart2
+        preferencesSubscription = watchRelatedSettings
             .debounce(for: .seconds(1), scheduler: RunLoop.main)
             .sink { _ in } receiveValue: { _ in
                 self.syncPreferencesToWatch()
@@ -127,13 +115,13 @@ class WatchMessageService: NSObject, WCSessionDelegate {
 extension WatchPreferences {
     init(fromPreferences preferences: Preferences.Type) {
         self.init(
-            localUrl: preferences.localUrl,
-            remoteUrl: preferences.remoteUrl,
-            username: preferences.username,
-            password: preferences.password,
-            alwaysSendCreds: preferences.alwaysSendCreds,
+            localUrl: preferences.localConnectionConfig.url,
+            remoteUrl: preferences.remoteConnectionConfig.url,
+            username: preferences.remoteConnectionConfig.username,
+            password: preferences.remoteConnectionConfig.password,
+            alwaysSendCreds: preferences.remoteConnectionConfig.alwaysSendBasicAuth,
             defaultSitemap: preferences.defaultSitemap,
-            ignoreSSL: preferences.ignoreSSL,
+            ignoreSSL: preferences.remoteConnectionConfig.ignoreSSL,
             sitemapForWatch: preferences.sitemapForWatch,
             sitemapForWatchLabel: preferences.sitemapForWatchLabel,
             iconType: preferences.iconType,

--- a/openHAB/WatchMessageService.swift
+++ b/openHAB/WatchMessageService.swift
@@ -22,7 +22,7 @@ class WatchMessageService: NSObject, WCSessionDelegate {
 
     private lazy var logger = Logger(subsystem: "org.openhab.app", category: "WatchMessageService")
 
-    private var cachedWatchPreferences: [String: Any] = [:]
+    private var cachedWatchPreferences: [String: Data] = [:]
     private let lock = NSLock()
 
     // This method gets called when the watch requests the data
@@ -64,6 +64,11 @@ class WatchMessageService: NSObject, WCSessionDelegate {
 
         let prefs = WatchPreferences(fromPreferences: Preferences.self)
         let context = prefs.encodedWatchPreferences()
+
+        guard cachedWatchPreferences != context else {
+            // avoid update of update unchanged preferences
+            return
+        }
 
         lock.lock()
         cachedWatchPreferences = context


### PR DESCRIPTION
In these commits, I leverage the Combine framework to change the watch- and crashlytics settings whenever the corresponding preferences change, eliminating redundancy and a potential source of developer error.
I also cleaned up the getter / setter logic of preferences to UserDefaults and moved the getter / setter implementation to static Preferences methods.