### PR TITLE
Intent adaptations for multiple homes

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Util/NetworkTracker.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/NetworkTracker.swift
@@ -353,6 +353,7 @@ public final class NetworkTracker: ObservableObject {
         activeConnection = connection
         status = connection == nil ? .notConnected : .connected
         if let connection {
+            // TODO: suspicious call to "shared" instance with specific connection
             KingfisherManager.shared.defaultOptions = [.requestModifier(OpenHABAccessTokenAdapter(connectionConfiguration: connection.configuration))]
         } else {
             startRetryTask(30)
@@ -381,42 +382,42 @@ public extension NetworkTracker {
     }
 
     func send(to item: String, command: String) async throws {
-        guard let activeConnection = await NetworkTracker.shared.waitForActiveConnection() else { return }
+        guard let activeConnection = await waitForActiveConnection() else { return }
         let configuration = activeConnection.configuration
         let service = try await connectionPool.getOrCreateService(for: configuration)
         try await service.sendItemCommand(itemname: item, command: command)
     }
 
-    func updateState(for item: OpenHABItem, state: String) async throws {
-        guard let activeConnection = await NetworkTracker.shared.waitForActiveConnection() else { return }
+    func updateState(item: OpenHABItem, state: String) async throws {
+        guard let activeConnection = await waitForActiveConnection() else { return }
         let configuration = activeConnection.configuration
         let service = try await connectionPool.getOrCreateService(for: configuration)
         try await service.updateItemState(itemname: item.name, with: state)
     }
 
     func getItems() async throws -> [OpenHABItem] {
-        guard let activeConnection = await NetworkTracker.shared.waitForActiveConnection() else { return [] }
+        guard let activeConnection = await waitForActiveConnection() else { return [] }
         let configuration = activeConnection.configuration
         let service = try await connectionPool.getOrCreateService(for: configuration)
         return try await service.getItems()
     }
 
     func getItemByName(id: String) async throws -> OpenHABItem? {
-        guard let activeConnection = await NetworkTracker.shared.waitForActiveConnection() else { return nil }
+        guard let activeConnection = await waitForActiveConnection() else { return nil }
         let configuration = activeConnection.configuration
         let service = try await connectionPool.getOrCreateService(for: configuration)
         return try await service.getItemByName(id: id)
     }
 
     func pollDataForPage(sitemapname: String, pageId: String = "", longPolling: Bool = false) async throws -> OpenHABPage? {
-        guard let activeConnection = await NetworkTracker.shared.waitForActiveConnection() else { return nil }
+        guard let activeConnection = await waitForActiveConnection() else { return nil }
         let configuration = activeConnection.configuration
         let service = try await connectionPool.getOrCreateService(for: configuration)
         return try await service.pollDataForPage(sitemapname: sitemapname, pageId: pageId, longPolling: longPolling)
     }
 
     func runNow(ruleUID: String, payload: [String: String]) async throws {
-        guard let activeConnection = await NetworkTracker.shared.waitForActiveConnection() else { throw NetworkTrackerError.noActiveConnection }
+        guard let activeConnection = await waitForActiveConnection() else { throw NetworkTrackerError.noActiveConnection }
         let configuration = activeConnection.configuration
         let service = try await connectionPool.getOrCreateService(for: configuration)
         try await service.runNow(ruleUID: ruleUID, payload: payload)

--- a/OpenHABCore/Sources/OpenHABCore/Util/OpenHABItemCache.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/OpenHABItemCache.swift
@@ -13,40 +13,31 @@ import Combine
 import Foundation
 import os.log
 
-public protocol ItemCacheProtocol {
-    func getItem(name: String) async -> OpenHABItem?
-    func sendCommand(_ item: OpenHABItem, commandToSend: String) async
-    func getItemNames(searchTerm: String?, types: [OpenHABItem.ItemType]?) async -> [String]
-    func sendState(_ item: OpenHABItem, stateToSend: String) async
-}
-
 public actor OpenHABItemCache {
     private static let logger = Logger(subsystem: "org.openhab.app.openHABIntents", category: "OpenHABItemCache")
+    private static var networkTrackers: [UUID: NetworkTracker] = [:]
+
     public static let instance = OpenHABItemCache()
 
-    private lazy var setupTask: Task<Void, Never> = Task { [weak self] in
-        await self?.setup()
-    }
-
-    public var items: [UUID: [OpenHABItem]]?
+    public var items: [UUID: [OpenHABItem]] = [:]
     private let ttl: TimeInterval = 20
-    var lastLoad = Date()
+    var lastLoad: [UUID: Date] = [:]
 
     private let logger = Logger(subsystem: "org.openhab.app.openHABIntents", category: "OpenHABItemCache")
 
     private init() {}
 
-    static func getNonGroupItemsForAllHomes() async throws -> [UUID: [OpenHABItem]] {
-        let allItemsArray = try await getItemsForAllHomes().map { (uuid, items) in (uuid, items.filter { $0.type != .group }) }
+    static func loadNonGroupItemsForHomes(_ homes: [UUID]) async throws -> [UUID: [OpenHABItem]] {
+        let allItemsArray = try await loadItemsForHomes(homes).map { (uuid, items) in (uuid, items.filter { $0.type != .group }) }
         return Dictionary(uniqueKeysWithValues: allItemsArray)
     }
 
-    static func getItemsForAllHomes() async throws -> [UUID: [OpenHABItem]] {
+    static func loadItemsForHomes(_ homes: [UUID]) async throws -> [UUID: [OpenHABItem]] {
         await withThrowingTaskGroup { @Sendable group in
-            for homeId in await Preferences.storedHomes.keys {
+            for homeId in homes {
                 group.addTask {
                     // TODO: consider the possibility that two local connections might be the same
-                    guard let items = await OpenHABItemCache.getItems(homeId: homeId) else {
+                    guard let items = await loadItems(homeId: homeId) else {
                         logger.error("Item search for home with id \(homeId) failed")
                         return (id: homeId, items: [] as [OpenHABItem])
                     }
@@ -66,152 +57,102 @@ public actor OpenHABItemCache {
         }
     }
 
-    static func getItems(homeId: UUID) async -> [OpenHABItem]? {
-        if await homeId == Preferences.currentHomePreferences.id {
-            return try? await NetworkTracker.shared.getItems()
-        } else {
-            guard let homePreferences = await Preferences.storedHomes[homeId] else {
-                Logger(subsystem: "org.openhab.app.watchkitapp", category: "OpenHABItemCache")
-                    .error("No home for id \(homeId) found")
-                return nil
-            }
-            return await performWithTemporaryNetworkTracker(for: homePreferences) { networkTracker in
-                try? await networkTracker.getItems()
-            }
+    static func loadItems(homeId: UUID) async -> [OpenHABItem]? {
+        guard let networkTracker = await OpenHABItemCache.assureNetworkTracker(homeId: homeId) else {
+            logger.error("Home \(homeId) not reachable")
+            return nil
         }
+        return try? await networkTracker.getItems()
     }
 
-    static func performWithTemporaryNetworkTracker<T: Sendable>(for home: HomePreferences,
-                                                                actions: (_ networkTracker: NetworkTracker) async throws -> T) async rethrows -> T {
-        let networkTracker = NetworkTracker()
-        await networkTracker.startTracking(connectionConfigurations: [home.remoteConnectionConfig, home.localConnectionConfig])
-        // TODO: I would love to use defer here to make sure the network tracker stops, but stopTracking() is async and not allowed in defer.
-        let result: T
+    static func assureNetworkTracker(homeId: UUID) async -> NetworkTracker? {
+        if networkTrackers[homeId] == nil, let homePreferences = Preferences.storedHomes[homeId] {
+            let tracker = NetworkTracker()
+            networkTrackers[homeId] = tracker
+            await tracker.startTracking(connectionConfigurations: [homePreferences.localConnectionConfig, homePreferences.remoteConnectionConfig])
+        }
+        // TODO: do we need to make sure / wait that the connection is live?
+        return networkTrackers[homeId]
+    }
+
+    public func getAllCachedItems() async -> [UUID: [OpenHABItem]] {
+        await reloadCacheIfNeeded(homes: Preferences.listStoredHomes())
+        return items
+    }
+
+    public func getCachedItem(name: String, home: UUID) async -> [OpenHABItem]? {
+        await reloadCacheIfNeeded(homes: [home])
+        return items[home]?.filter { $0.name == name }
+    }
+
+    public func sendCommand(to item: OpenHABItem, home: UUID, command: String) async {
+        guard let networkTracker = await OpenHABItemCache.assureNetworkTracker(homeId: home) else {
+            logger.error("Home \(home) not reachable")
+            return
+        }
+
         do {
-            result = try await actions(networkTracker)
-        } catch {
-            await networkTracker.stopTracking()
-            throw error
-        }
-        await networkTracker.stopTracking()
-        return result
-    }
-
-    public func waitUntilReady() async {
-        await setupTask.value
-    }
-
-    public func setup() async {
-        let connection1: ConnectionConfiguration = await Preferences.currentHomePreferences.localConnectionConfig
-        let connection2: ConnectionConfiguration = await Preferences.currentHomePreferences.remoteConnectionConfig
-        logger.info("Local: \(connection1.url), Remote: \(connection2.url)")
-        await NetworkTracker.shared.startTracking(connectionConfigurations: [connection1, connection2])
-    }
-
-    public func getItemNames(searchTerm: String?, types: [OpenHABItem.ItemType]?) async -> [String] {
-        logger.info("getItemNames")
-        guard let items else {
-            return await reload(searchTerm: searchTerm, types: types)
-        }
-
-        return items.flatMap { (_, items: [OpenHABItem]) in items }
-            .filtered(by: searchTerm, for: types)
-            .sorted(by: \.name)
-            .map(\.name)
-    }
-
-    public func getItem(name: String) async -> OpenHABItem? {
-        logger.info("getItem")
-        let now = Date()
-
-        if items == nil || now.timeIntervalSince(lastLoad) > ttl {
-            return await reload(name: name)
-        }
-        return getItem(name)
-    }
-
-    func getItem(_ name: String) -> OpenHABItem? {
-        // TODO: consider associated home
-        items?.flatMap { (_: UUID, items: [OpenHABItem]) in items }
-            .first { $0.name == name }
-    }
-
-    public func sendCommand(_ item: OpenHABItem, commandToSend command: String) async {
-        do {
-            try await sendCommand(to: item, command: command)
+            try await networkTracker.send(to: item, command: command)
         } catch {
             logger.info("Could not send command: \(error.localizedDescription)")
         }
     }
 
-    func sendCommand(to item: OpenHABItem, home: UUID? = nil, command: String) async throws {
-        if let home, await home != Preferences.currentHomePreferences.id {
-            guard let homeConfig = await Preferences.storedHomes[home] else { return } // TODO: log warning (or throw?)
-            try await OpenHABItemCache.performWithTemporaryNetworkTracker(for: homeConfig) { networkTracker in
-                try await networkTracker.send(to: item, command: command)
-            }
-        } else {
-            try await NetworkTracker.shared.send(to: item, command: command)
+    public func sendState(_ item: OpenHABItem, home: UUID, state: String) async {
+        guard let networkTracker = await OpenHABItemCache.assureNetworkTracker(homeId: home) else {
+            logger.error("Home \(home) not reachable")
+            return
         }
-    }
 
-    public func sendState(_ item: OpenHABItem, stateToSend state: String) async {
         do {
-            try await sendState(for: item, state: state)
+            try await networkTracker.updateState(item: item, state: state)
         } catch {
             logger.info("Could not send state: \(error.localizedDescription)")
         }
     }
 
-    func sendState(for item: OpenHABItem, home: UUID? = nil, state: String) async throws {
-        if let home, await home != Preferences.currentHomePreferences.id {
-            guard let homeConfig = await Preferences.storedHomes[home] else { return } // TODO: log warning (or throw?)
-            try await OpenHABItemCache.performWithTemporaryNetworkTracker(for: homeConfig) { networkTracker in
-                try await networkTracker.updateState(item: item, state: state)
-            }
-        } else {
-            try await NetworkTracker.shared.updateState(item: item, state: state)
+    public func reloadCacheIfNeeded(homes: [UUID]) async {
+        let homesNeedingReload = homes.filter { Date.now.timeIntervalSince(lastLoad[$0] ?? Date.distantPast) > ttl }
+        await forceCacheReload(homes: homesNeedingReload)
+    }
+
+    public func forceCacheReload(homes: [UUID]) async {
+        logger.info("reload items")
+        do {
+            let loadedItems = try await OpenHABItemCache.loadNonGroupItemsForHomes(homes)
+            homes.forEach { items[$0] = loadedItems[$0] }
+            let now = Date.now
+            homes.forEach { lastLoad[$0] = now }
+            let itemCounts = items.map { ($0.key, $0.value.count) }
+            logger.info("Loaded \(itemCounts) items to cache")
+        } catch {
+            logger.error("Could not reload \(error.localizedDescription)")
         }
     }
 
-    public func reload(searchTerm: String?, types: [OpenHABItem.ItemType]?) async -> [String] {
-        logger.info("OpenHABItemCache Loading items ")
+    public func forceCacheReload() async {
+        let homes = Preferences.listStoredHomes()
+        // some house keeping
+        let networkTrackersToRemove = OpenHABItemCache.networkTrackers.filter { !homes.contains($0.key) }
+        for networkTracker in networkTrackersToRemove {
+            await networkTracker.value.stopTracking()
+            OpenHABItemCache.networkTrackers.removeValue(forKey: networkTracker.key)
+        }
+        items = [:]
+        lastLoad = [:]
+        await forceCacheReload(homes: homes)
+    }
 
-        do {
-            items = try await OpenHABItemCache.getNonGroupItemsForAllHomes()
-            // swiftformat:disable next redundantSelf
-            lastLoad = Date()
-            logger.info("Loaded \(self.items?.count ?? 0) items to cache")
-            return items?.flatMap { (_: UUID, items: [OpenHABItem]) in
-                items
-            }
+    func matchingItemNames(_ itemsList: [OpenHABItem], searchTerm: String? = nil, types: [OpenHABItem.ItemType]? = nil) -> [String] {
+        itemsList
             .filtered(by: searchTerm, for: types)
-            .sorted(by: \.name)
-            .map(\.name) ?? []
-        } catch {
-            logger.error("Could not reload \(error.localizedDescription)")
-            return []
-        }
-    }
-
-    public func reload(name: String) async -> OpenHABItem? {
-        do {
-            items = try await OpenHABItemCache.getNonGroupItemsForAllHomes()
-            return items?.flatMap { (_: UUID, items: [OpenHABItem]) in
-                items
-            }
-            .first { $0.name == name }
-        } catch {
-            logger.error("Could not reload \(error.localizedDescription)")
-            return nil
-        }
+            .map(\.name)
+            .sorted()
     }
 }
 
-extension OpenHABItemCache: ItemCacheProtocol {}
-
-private extension [OpenHABItem] {
-    func filtered(by searchTerm: String?, for types: [OpenHABItem.ItemType]?) -> [OpenHABItem] {
+public extension [OpenHABItem] {
+    func filtered(by searchTerm: String? = nil, for types: [OpenHABItem.ItemType]? = nil) -> [OpenHABItem] {
         // TODO: maybe allow home name for filtering and fuzzier search
         filter {
             (searchTerm == nil || $0.name.contains(searchTerm.orEmpty)) &&

--- a/OpenHABCore/Sources/OpenHABCore/Util/OpenHABItemCache.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/OpenHABItemCache.swift
@@ -80,6 +80,11 @@ public actor OpenHABItemCache {
         return items
     }
 
+    public func getCachedItems(home: UUID) async -> [OpenHABItem]? {
+        await reloadCacheIfNeeded(homes: [home])
+        return items[home]
+    }
+
     public func getCachedItem(name: String, home: UUID) async -> [OpenHABItem]? {
         await reloadCacheIfNeeded(homes: [home])
         return items[home]?.filter { $0.name == name }

--- a/OpenHABCore/Sources/OpenHABCore/Util/OpenHABItemCache.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/OpenHABItemCache.swift
@@ -21,19 +21,81 @@ public protocol ItemCacheProtocol {
 }
 
 public actor OpenHABItemCache {
+    private static let logger = Logger(subsystem: "org.openhab.app.openHABIntents", category: "OpenHABItemCache")
     public static let instance = OpenHABItemCache()
 
     private lazy var setupTask: Task<Void, Never> = Task { [weak self] in
         await self?.setup()
     }
 
-    public var items: [OpenHABItem]?
+    public var items: [UUID: [OpenHABItem]]?
     private let ttl: TimeInterval = 20
     var lastLoad = Date()
 
-    private let logger = Logger(subsystem: "org.openhab.app.watchkitapp", category: "OpenHABItemCache")
+    private let logger = Logger(subsystem: "org.openhab.app.openHABIntents", category: "OpenHABItemCache")
 
     private init() {}
+
+    static func getNonGroupItemsForAllHomes() async throws -> [UUID: [OpenHABItem]] {
+        let allItemsArray = try await getItemsForAllHomes().map { (uuid, items) in (uuid, items.filter { $0.type != .group }) }
+        return Dictionary(uniqueKeysWithValues: allItemsArray)
+    }
+
+    static func getItemsForAllHomes() async throws -> [UUID: [OpenHABItem]] {
+        await withThrowingTaskGroup { @Sendable group in
+            for homeId in await Preferences.storedHomes.keys {
+                group.addTask {
+                    // TODO: consider the possibility that two local connections might be the same
+                    guard let items = await OpenHABItemCache.getItems(homeId: homeId) else {
+                        logger.error("Item search for home with id \(homeId) failed")
+                        return (id: homeId, items: [] as [OpenHABItem])
+                    }
+                    return (id: homeId, items: items)
+                }
+            }
+            let homeItemsDictionary: [UUID: [OpenHABItem]] = [:]
+            let allHomeItems = try? await group.reduce(into: homeItemsDictionary) { partialResult, nextElement in
+                logger.debug("Found \(nextElement.items.count) items for \(nextElement.id)")
+                partialResult[nextElement.id] = nextElement.items
+            }
+            guard let allHomeItems else {
+                logger.error("Item search failed!")
+                return [:]
+            }
+            return allHomeItems
+        }
+    }
+
+    static func getItems(homeId: UUID) async -> [OpenHABItem]? {
+        if await homeId == Preferences.currentHomePreferences.id {
+            return try? await NetworkTracker.shared.getItems()
+        } else {
+            guard let homePreferences = await Preferences.storedHomes[homeId] else {
+                Logger(subsystem: "org.openhab.app.watchkitapp", category: "OpenHABItemCache")
+                    .error("No home for id \(homeId) found")
+                return nil
+            }
+            return await performWithTemporaryNetworkTracker(for: homePreferences) { networkTracker in
+                try? await networkTracker.getItems()
+            }
+        }
+    }
+
+    static func performWithTemporaryNetworkTracker<T: Sendable>(for home: HomePreferences,
+                                                                actions: (_ networkTracker: NetworkTracker) async throws -> T) async rethrows -> T {
+        let networkTracker = NetworkTracker()
+        await networkTracker.startTracking(connectionConfigurations: [home.remoteConnectionConfig, home.localConnectionConfig])
+        // TODO: I would love to use defer here to make sure the network tracker stops, but stopTracking() is async and not allowed in defer.
+        let result: T
+        do {
+            result = try await actions(networkTracker)
+        } catch {
+            await networkTracker.stopTracking()
+            throw error
+        }
+        await networkTracker.stopTracking()
+        return result
+    }
 
     public func waitUntilReady() async {
         await setupTask.value
@@ -52,7 +114,8 @@ public actor OpenHABItemCache {
             return await reload(searchTerm: searchTerm, types: types)
         }
 
-        return items.filtered(by: searchTerm, for: types)
+        return items.flatMap { (_, items: [OpenHABItem]) in items }
+            .filtered(by: searchTerm, for: types)
             .sorted(by: \.name)
             .map(\.name)
     }
@@ -68,22 +131,46 @@ public actor OpenHABItemCache {
     }
 
     func getItem(_ name: String) -> OpenHABItem? {
-        items?.first { $0.name == name }
+        // TODO: consider associated home
+        items?.flatMap { (_: UUID, items: [OpenHABItem]) in items }
+            .first { $0.name == name }
     }
 
     public func sendCommand(_ item: OpenHABItem, commandToSend command: String) async {
         do {
-            try await NetworkTracker.shared.send(to: item, command: command)
+            try await sendCommand(to: item, command: command)
         } catch {
             logger.info("Could not send command: \(error.localizedDescription)")
         }
     }
 
+    func sendCommand(to item: OpenHABItem, home: UUID? = nil, command: String) async throws {
+        if let home, await home != Preferences.currentHomePreferences.id {
+            guard let homeConfig = await Preferences.storedHomes[home] else { return } // TODO: log warning (or throw?)
+            try await OpenHABItemCache.performWithTemporaryNetworkTracker(for: homeConfig) { networkTracker in
+                try await networkTracker.send(to: item, command: command)
+            }
+        } else {
+            try await NetworkTracker.shared.send(to: item, command: command)
+        }
+    }
+
     public func sendState(_ item: OpenHABItem, stateToSend state: String) async {
         do {
-            try await NetworkTracker.shared.updateState(for: item, state: state)
+            try await sendState(for: item, state: state)
         } catch {
             logger.info("Could not send state: \(error.localizedDescription)")
+        }
+    }
+
+    func sendState(for item: OpenHABItem, home: UUID? = nil, state: String) async throws {
+        if let home, await home != Preferences.currentHomePreferences.id {
+            guard let homeConfig = await Preferences.storedHomes[home] else { return } // TODO: log warning (or throw?)
+            try await OpenHABItemCache.performWithTemporaryNetworkTracker(for: homeConfig) { networkTracker in
+                try await networkTracker.updateState(item: item, state: state)
+            }
+        } else {
+            try await NetworkTracker.shared.updateState(item: item, state: state)
         }
     }
 
@@ -91,11 +178,16 @@ public actor OpenHABItemCache {
         logger.info("OpenHABItemCache Loading items ")
 
         do {
-            items = try await NetworkTracker.shared.getItems().filter { $0.type != .group }
+            items = try await OpenHABItemCache.getNonGroupItemsForAllHomes()
             // swiftformat:disable next redundantSelf
             lastLoad = Date()
             logger.info("Loaded \(self.items?.count ?? 0) items to cache")
-            return items?.filtered(by: searchTerm, for: types).sorted(by: \.name).map(\.name) ?? []
+            return items?.flatMap { (_: UUID, items: [OpenHABItem]) in
+                items
+            }
+            .filtered(by: searchTerm, for: types)
+            .sorted(by: \.name)
+            .map(\.name) ?? []
         } catch {
             logger.error("Could not reload \(error.localizedDescription)")
             return []
@@ -104,8 +196,11 @@ public actor OpenHABItemCache {
 
     public func reload(name: String) async -> OpenHABItem? {
         do {
-            items = try await NetworkTracker.shared.getItems().filter { $0.type != .group }
-            return items?.first { $0.name == name }
+            items = try await OpenHABItemCache.getNonGroupItemsForAllHomes()
+            return items?.flatMap { (_: UUID, items: [OpenHABItem]) in
+                items
+            }
+            .first { $0.name == name }
         } catch {
             logger.error("Could not reload \(error.localizedDescription)")
             return nil
@@ -117,6 +212,7 @@ extension OpenHABItemCache: ItemCacheProtocol {}
 
 private extension [OpenHABItem] {
     func filtered(by searchTerm: String?, for types: [OpenHABItem.ItemType]?) -> [OpenHABItem] {
+        // TODO: maybe allow home name for filtering and fuzzier search
         filter {
             (searchTerm == nil || $0.name.contains(searchTerm.orEmpty)) &&
                 (types == nil || ($0.type != nil && types!.contains($0.type!)))

--- a/OpenHABCore/Sources/OpenHABCore/Util/OpenHABItemCache.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/OpenHABItemCache.swift
@@ -14,10 +14,9 @@ import Foundation
 import os.log
 
 public actor OpenHABItemCache {
-    private static let logger = Logger(subsystem: "org.openhab.app.openHABIntents", category: "OpenHABItemCache")
-    private static var networkTrackers: [UUID: NetworkTracker] = [:]
-
     public static let instance = OpenHABItemCache()
+
+    private var networkTrackers: [UUID: NetworkTracker] = [:]
 
     public var items: [UUID: [OpenHABItem]] = [:]
     private let ttl: TimeInterval = 20
@@ -26,54 +25,6 @@ public actor OpenHABItemCache {
     private let logger = Logger(subsystem: "org.openhab.app.openHABIntents", category: "OpenHABItemCache")
 
     private init() {}
-
-    static func loadNonGroupItemsForHomes(_ homes: [UUID]) async throws -> [UUID: [OpenHABItem]] {
-        let allItemsArray = try await loadItemsForHomes(homes).map { (uuid, items) in (uuid, items.filter { $0.type != .group }) }
-        return Dictionary(uniqueKeysWithValues: allItemsArray)
-    }
-
-    static func loadItemsForHomes(_ homes: [UUID]) async throws -> [UUID: [OpenHABItem]] {
-        await withThrowingTaskGroup { @Sendable group in
-            for homeId in homes {
-                group.addTask {
-                    // TODO: consider the possibility that two local connections might be the same
-                    guard let items = await loadItems(homeId: homeId) else {
-                        logger.error("Item search for home with id \(homeId) failed")
-                        return (id: homeId, items: [] as [OpenHABItem])
-                    }
-                    return (id: homeId, items: items)
-                }
-            }
-            let homeItemsDictionary: [UUID: [OpenHABItem]] = [:]
-            let allHomeItems = try? await group.reduce(into: homeItemsDictionary) { partialResult, nextElement in
-                logger.debug("Found \(nextElement.items.count) items for \(nextElement.id)")
-                partialResult[nextElement.id] = nextElement.items
-            }
-            guard let allHomeItems else {
-                logger.error("Item search failed!")
-                return [:]
-            }
-            return allHomeItems
-        }
-    }
-
-    static func loadItems(homeId: UUID) async -> [OpenHABItem]? {
-        guard let networkTracker = await OpenHABItemCache.assureNetworkTracker(homeId: homeId) else {
-            logger.error("Home \(homeId) not reachable")
-            return nil
-        }
-        return try? await networkTracker.getItems()
-    }
-
-    static func assureNetworkTracker(homeId: UUID) async -> NetworkTracker? {
-        if networkTrackers[homeId] == nil, let homePreferences = Preferences.storedHomes[homeId] {
-            let tracker = NetworkTracker()
-            networkTrackers[homeId] = tracker
-            await tracker.startTracking(connectionConfigurations: [homePreferences.localConnectionConfig, homePreferences.remoteConnectionConfig])
-        }
-        // TODO: do we need to make sure / wait that the connection is live?
-        return networkTrackers[homeId]
-    }
 
     public func getAllCachedItems() async -> [UUID: [OpenHABItem]] {
         await reloadCacheIfNeeded(homes: Preferences.listStoredHomes())
@@ -91,7 +42,7 @@ public actor OpenHABItemCache {
     }
 
     public func sendCommand(to item: OpenHABItem, home: UUID, command: String) async {
-        guard let networkTracker = await OpenHABItemCache.assureNetworkTracker(homeId: home) else {
+        guard let networkTracker = await assureNetworkTracker(homeId: home) else {
             logger.error("Home \(home) not reachable")
             return
         }
@@ -104,7 +55,7 @@ public actor OpenHABItemCache {
     }
 
     public func sendState(_ item: OpenHABItem, home: UUID, state: String) async {
-        guard let networkTracker = await OpenHABItemCache.assureNetworkTracker(homeId: home) else {
+        guard let networkTracker = await assureNetworkTracker(homeId: home) else {
             logger.error("Home \(home) not reachable")
             return
         }
@@ -124,7 +75,7 @@ public actor OpenHABItemCache {
     public func forceCacheReload(homes: [UUID]) async {
         logger.info("reload items")
         do {
-            let loadedItems = try await OpenHABItemCache.loadNonGroupItemsForHomes(homes)
+            let loadedItems = try await loadNonGroupItemsForHomes(homes)
             homes.forEach { items[$0] = loadedItems[$0] }
             let now = Date.now
             homes.forEach { lastLoad[$0] = now }
@@ -138,10 +89,10 @@ public actor OpenHABItemCache {
     public func forceCacheReload() async {
         let homes = Preferences.listStoredHomes()
         // some house keeping
-        let networkTrackersToRemove = OpenHABItemCache.networkTrackers.filter { !homes.contains($0.key) }
+        let networkTrackersToRemove = networkTrackers.filter { !homes.contains($0.key) }
         for networkTracker in networkTrackersToRemove {
             await networkTracker.value.stopTracking()
-            OpenHABItemCache.networkTrackers.removeValue(forKey: networkTracker.key)
+            networkTrackers.removeValue(forKey: networkTracker.key)
         }
         items = [:]
         lastLoad = [:]
@@ -153,6 +104,54 @@ public actor OpenHABItemCache {
             .filtered(by: searchTerm, for: types)
             .map(\.name)
             .sorted()
+    }
+
+    private func loadNonGroupItemsForHomes(_ homes: [UUID]) async throws -> [UUID: [OpenHABItem]] {
+        let allItemsArray = try await loadItemsForHomes(homes).map { (uuid, items) in (uuid, items.filter { $0.type != .group }) }
+        return Dictionary(uniqueKeysWithValues: allItemsArray)
+    }
+
+    private func loadItemsForHomes(_ homes: [UUID]) async throws -> [UUID: [OpenHABItem]] {
+        await withThrowingTaskGroup { @Sendable group in
+            for homeId in homes {
+                group.addTask {
+                    // TODO: consider the possibility that two local connections might be the same
+                    guard let items = await self.loadItems(homeId: homeId) else {
+                        self.logger.error("Item search for home with id \(homeId) failed")
+                        return (id: homeId, items: [] as [OpenHABItem])
+                    }
+                    return (id: homeId, items: items)
+                }
+            }
+            let homeItemsDictionary: [UUID: [OpenHABItem]] = [:]
+            let allHomeItems = try? await group.reduce(into: homeItemsDictionary) { partialResult, nextElement in
+                logger.debug("Found \(nextElement.items.count) items for \(nextElement.id)")
+                partialResult[nextElement.id] = nextElement.items
+            }
+            guard let allHomeItems else {
+                logger.error("Item search failed!")
+                return [:]
+            }
+            return allHomeItems
+        }
+    }
+
+    private func loadItems(homeId: UUID) async -> [OpenHABItem]? {
+        guard let networkTracker = await assureNetworkTracker(homeId: homeId) else {
+            logger.error("Home \(homeId) not reachable")
+            return nil
+        }
+        return try? await networkTracker.getItems()
+    }
+
+    private func assureNetworkTracker(homeId: UUID) async -> NetworkTracker? {
+        if networkTrackers[homeId] == nil, let homePreferences = Preferences.storedHomes[homeId] {
+            let tracker = NetworkTracker()
+            networkTrackers[homeId] = tracker
+            await tracker.startTracking(connectionConfigurations: [homePreferences.localConnectionConfig, homePreferences.remoteConnectionConfig])
+        }
+        // TODO: do we need to make sure / wait that the connection is live?
+        return networkTrackers[homeId]
     }
 }
 

--- a/OpenHABCore/Sources/OpenHABCore/Util/Preferences.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/Preferences.swift
@@ -15,7 +15,7 @@ import UIKit
 
 private let logger = Logger(subsystem: "org.openhab", category: "Preferences")
 
-@propertyWrapper @MainActor
+@propertyWrapper
 public struct UserDefault<T: Sendable> {
     private let key: String
     private let defaultValue: T
@@ -44,7 +44,7 @@ public struct UserDefault<T: Sendable> {
     }
 }
 
-@propertyWrapper @MainActor
+@propertyWrapper
 public struct UserDefaultObject<T: Codable & Sendable> {
     private let key: String
     private let defaultValue: T
@@ -105,7 +105,6 @@ public struct HomePreferences: Codable, Sendable, Equatable {
     }
 }
 
-@MainActor
 public enum Preferences {
     /// the currently applied settings set from storedHomes
     @UserDefaultObject("currentHomePreferences", defaultValue: HomePreferences(id: Preferences.activeHomeId))

--- a/openHAB.xcodeproj/project.pbxproj
+++ b/openHAB.xcodeproj/project.pbxproj
@@ -712,13 +712,6 @@
 			path = Extension;
 			sourceTree = "<group>";
 		};
-		DA0DA9E02E0C9B51000C5D0A /* New Group */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = "New Group";
-			sourceTree = "<group>";
-		};
 		DA1C2E4A230DC28F00FACFB0 /* fastlane */ = {
 			isa = PBXGroup;
 			children = (
@@ -989,7 +982,6 @@
 		DFB2621E18830A3600D3244D = {
 			isa = PBXGroup;
 			children = (
-				DA0DA9E02E0C9B51000C5D0A /* New Group */,
 				6557AF8E2C0241C10094D0C8 /* PrivacyInfo.xcprivacy */,
 				DA4D4DB4233F9ACB00B37E37 /* README.md */,
 				DA4D4E0E2340A00200B37E37 /* Changes.md */,

--- a/openHAB.xcodeproj/project.pbxproj
+++ b/openHAB.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		2F6412EE2CE494A80039FB28 /* DatePickerUITableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F6412ED2CE494A80039FB28 /* DatePickerUITableViewCell.swift */; };
 		2FBCF58C2DEB0B7700CD5D83 /* HomeSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBCF58B2DEB0B7700CD5D83 /* HomeSelectionView.swift */; };
 		2FEFD8F62BE7C5BE00E387B9 /* TextInputUITableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FEFD8F52BE7C5BE00E387B9 /* TextInputUITableViewCell.swift */; };
+		2FF459362E230C6A00C0B640 /* OpenHABIntentHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF459352E230C6A00C0B640 /* OpenHABIntentHelper.swift */; };
 		4D6470DA2561F935007B03FC /* openHABIntents.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 4D6470D32561F935007B03FC /* openHABIntents.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		653B54C2285E714900298ECD /* OpenHABViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B54C1285E714900298ECD /* OpenHABViewController.swift */; };
 		65570A7D2476D16A00D524EA /* OpenHABWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65570A7C2476D16A00D524EA /* OpenHABWebViewController.swift */; };
@@ -281,6 +282,7 @@
 		2F6412ED2CE494A80039FB28 /* DatePickerUITableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerUITableViewCell.swift; sourceTree = "<group>"; };
 		2FBCF58B2DEB0B7700CD5D83 /* HomeSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSelectionView.swift; sourceTree = "<group>"; };
 		2FEFD8F52BE7C5BE00E387B9 /* TextInputUITableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextInputUITableViewCell.swift; sourceTree = "<group>"; };
+		2FF459352E230C6A00C0B640 /* OpenHABIntentHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenHABIntentHelper.swift; sourceTree = "<group>"; };
 		4D38D951256897490039DA6E /* SetNumberValueIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetNumberValueIntentHandler.swift; sourceTree = "<group>"; };
 		4D38D959256897770039DA6E /* SetStringValueIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetStringValueIntentHandler.swift; sourceTree = "<group>"; };
 		4D38D9612568978E0039DA6E /* SetColorValueIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetColorValueIntentHandler.swift; sourceTree = "<group>"; };
@@ -629,6 +631,7 @@
 				4D38D959256897770039DA6E /* SetStringValueIntentHandler.swift */,
 				4D38D9612568978E0039DA6E /* SetColorValueIntentHandler.swift */,
 				4D38D969256897AD0039DA6E /* SetContactStateValueIntentHandler.swift */,
+				2FF459352E230C6A00C0B640 /* OpenHABIntentHelper.swift */,
 			);
 			path = openHABIntents;
 			sourceTree = "<group>";
@@ -1482,6 +1485,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				937C8B0C2800A738009C055E /* Intents.intentdefinition in Sources */,
+				2FF459362E230C6A00C0B640 /* OpenHABIntentHelper.swift in Sources */,
 				93AEE42B27D9D796008EB207 /* SetContactStateValueIntentHandler.swift in Sources */,
 				93AEE42927D9D790008EB207 /* SetStringValueIntentHandler.swift in Sources */,
 				93AEE42527D9D76E008EB207 /* IntentHandler.swift in Sources */,

--- a/openHAB/HomeSelectionView.swift
+++ b/openHAB/HomeSelectionView.swift
@@ -84,7 +84,7 @@ struct HomeSelectionView: View {
                     }
                 }
             }
-            .alert("Enter new name for home \(homeNameForAlert)", isPresented: $showingRenameHomeAlert) {
+            .alert("Enter new name for home \(homeNameForAlert)", isPresented: $showingRenameHomeAlert, actions: {
                 TextField("New name", text: $newHomeName)
                 HStack {
                     Button("Abort", role: .cancel) {
@@ -94,10 +94,10 @@ struct HomeSelectionView: View {
                         rename(home: homeForAlert)
                         showingRenameHomeAlert.toggle()
                     }
-                } message: {
-                    Text("Renaming the home might cause external integrations like shortcuts to fail")
                 }
-            }
+            }, message: {
+                Text("Warning: Renaming the home might cause external integrations like shortcuts to fail until reconfigured")
+            })
             .alert("Delete home \(homeNameForAlert)?", isPresented: $showingDeleteHomeAlert) {
                 HStack {
                     Button("Abort", role: .cancel) {

--- a/openHAB/HomeSelectionView.swift
+++ b/openHAB/HomeSelectionView.swift
@@ -94,6 +94,8 @@ struct HomeSelectionView: View {
                         rename(home: homeForAlert)
                         showingRenameHomeAlert.toggle()
                     }
+                } message: {
+                    Text("Renaming the home might cause external integrations like shortcuts to fail")
                 }
             }
             .alert("Delete home \(homeNameForAlert)?", isPresented: $showingDeleteHomeAlert) {

--- a/openHAB/Resources/Base.lproj/Intents.intentdefinition
+++ b/openHAB/Resources/Base.lproj/Intents.intentdefinition
@@ -32,7 +32,7 @@
 			<key>INIntentKeyParameter</key>
 			<string>item</string>
 			<key>INIntentLastParameterTag</key>
-			<integer>4</integer>
+			<integer>5</integer>
 			<key>INIntentManagedParameterCombinations</key>
 			<dict>
 				<key>item,home</key>
@@ -106,17 +106,12 @@
 					<string>k6pj4o</string>
 					<key>INIntentParameterDisplayPriority</key>
 					<integer>2</integer>
-					<key>INIntentParameterMetadata</key>
-					<dict>
-						<key>INIntentParameterMetadataCapitalization</key>
-						<string>Sentences</string>
-						<key>INIntentParameterMetadataDefaultValue</key>
-						<string>"asdf"</string>
-						<key>INIntentParameterMetadataDefaultValueID</key>
-						<string>6BeO57</string>
-					</dict>
 					<key>INIntentParameterName</key>
 					<string>home</string>
+					<key>INIntentParameterObjectType</key>
+					<string>Home</string>
+					<key>INIntentParameterObjectTypeNamespace</key>
+					<string>aK4nIm</string>
 					<key>INIntentParameterPromptDialogs</key>
 					<array>
 						<dict>
@@ -175,9 +170,9 @@
 					<key>INIntentParameterSupportsResolution</key>
 					<true/>
 					<key>INIntentParameterTag</key>
-					<integer>4</integer>
+					<integer>5</integer>
 					<key>INIntentParameterType</key>
-					<string>String</string>
+					<string>Object</string>
 				</dict>
 			</array>
 			<key>INIntentResponse</key>
@@ -262,7 +257,7 @@
 			<key>INIntentKeyParameter</key>
 			<string>item</string>
 			<key>INIntentLastParameterTag</key>
-			<integer>3</integer>
+			<integer>4</integer>
 			<key>INIntentManagedParameterCombinations</key>
 			<dict>
 				<key>item,action,home</key>
@@ -396,15 +391,12 @@
 					<string>X9cN9h</string>
 					<key>INIntentParameterDisplayPriority</key>
 					<integer>3</integer>
-					<key>INIntentParameterMetadata</key>
-					<dict>
-						<key>INIntentParameterMetadataCapitalization</key>
-						<string>Sentences</string>
-						<key>INIntentParameterMetadataDefaultValueID</key>
-						<string>6BeO57</string>
-					</dict>
 					<key>INIntentParameterName</key>
 					<string>home</string>
+					<key>INIntentParameterObjectType</key>
+					<string>Home</string>
+					<key>INIntentParameterObjectTypeNamespace</key>
+					<string>aK4nIm</string>
 					<key>INIntentParameterPromptDialogs</key>
 					<array>
 						<dict>
@@ -459,9 +451,9 @@
 					<key>INIntentParameterSupportsResolution</key>
 					<true/>
 					<key>INIntentParameterTag</key>
-					<integer>3</integer>
+					<integer>4</integer>
 					<key>INIntentParameterType</key>
-					<string>String</string>
+					<string>Object</string>
 				</dict>
 			</array>
 			<key>INIntentResponse</key>
@@ -556,7 +548,7 @@
 			<key>INIntentKeyParameter</key>
 			<string>item</string>
 			<key>INIntentLastParameterTag</key>
-			<integer>4</integer>
+			<integer>5</integer>
 			<key>INIntentManagedParameterCombinations</key>
 			<dict>
 				<key>item,value,home</key>
@@ -684,15 +676,12 @@
 					<string>ZuBsOg</string>
 					<key>INIntentParameterDisplayPriority</key>
 					<integer>3</integer>
-					<key>INIntentParameterMetadata</key>
-					<dict>
-						<key>INIntentParameterMetadataCapitalization</key>
-						<string>Sentences</string>
-						<key>INIntentParameterMetadataDefaultValueID</key>
-						<string>6BeO57</string>
-					</dict>
 					<key>INIntentParameterName</key>
 					<string>home</string>
+					<key>INIntentParameterObjectType</key>
+					<string>Home</string>
+					<key>INIntentParameterObjectTypeNamespace</key>
+					<string>aK4nIm</string>
 					<key>INIntentParameterPromptDialogs</key>
 					<array>
 						<dict>
@@ -747,9 +736,9 @@
 					<key>INIntentParameterSupportsResolution</key>
 					<true/>
 					<key>INIntentParameterTag</key>
-					<integer>4</integer>
+					<integer>5</integer>
 					<key>INIntentParameterType</key>
-					<string>String</string>
+					<string>Object</string>
 				</dict>
 			</array>
 			<key>INIntentResponse</key>
@@ -852,7 +841,7 @@
 			<key>INIntentKeyParameter</key>
 			<string>item</string>
 			<key>INIntentLastParameterTag</key>
-			<integer>5</integer>
+			<integer>6</integer>
 			<key>INIntentManagedParameterCombinations</key>
 			<dict>
 				<key>item,value,home</key>
@@ -980,15 +969,12 @@
 					<string>zLlY3g</string>
 					<key>INIntentParameterDisplayPriority</key>
 					<integer>3</integer>
-					<key>INIntentParameterMetadata</key>
-					<dict>
-						<key>INIntentParameterMetadataCapitalization</key>
-						<string>Sentences</string>
-						<key>INIntentParameterMetadataDefaultValueID</key>
-						<string>6BeO57</string>
-					</dict>
 					<key>INIntentParameterName</key>
 					<string>home</string>
+					<key>INIntentParameterObjectType</key>
+					<string>Home</string>
+					<key>INIntentParameterObjectTypeNamespace</key>
+					<string>aK4nIm</string>
 					<key>INIntentParameterPromptDialogs</key>
 					<array>
 						<dict>
@@ -1043,9 +1029,9 @@
 					<key>INIntentParameterSupportsResolution</key>
 					<true/>
 					<key>INIntentParameterTag</key>
-					<integer>5</integer>
+					<integer>6</integer>
 					<key>INIntentParameterType</key>
-					<string>String</string>
+					<string>Object</string>
 				</dict>
 			</array>
 			<key>INIntentResponse</key>
@@ -1140,7 +1126,7 @@
 			<key>INIntentKeyParameter</key>
 			<string>item</string>
 			<key>INIntentLastParameterTag</key>
-			<integer>6</integer>
+			<integer>7</integer>
 			<key>INIntentManagedParameterCombinations</key>
 			<dict>
 				<key>item,value,home</key>
@@ -1274,15 +1260,12 @@
 					<string>71MWtI</string>
 					<key>INIntentParameterDisplayPriority</key>
 					<integer>3</integer>
-					<key>INIntentParameterMetadata</key>
-					<dict>
-						<key>INIntentParameterMetadataCapitalization</key>
-						<string>Sentences</string>
-						<key>INIntentParameterMetadataDefaultValueID</key>
-						<string>6BeO57</string>
-					</dict>
 					<key>INIntentParameterName</key>
 					<string>home</string>
+					<key>INIntentParameterObjectType</key>
+					<string>Home</string>
+					<key>INIntentParameterObjectTypeNamespace</key>
+					<string>aK4nIm</string>
 					<key>INIntentParameterPromptDialogs</key>
 					<array>
 						<dict>
@@ -1337,9 +1320,9 @@
 					<key>INIntentParameterSupportsResolution</key>
 					<true/>
 					<key>INIntentParameterTag</key>
-					<integer>6</integer>
+					<integer>7</integer>
 					<key>INIntentParameterType</key>
-					<string>String</string>
+					<string>Object</string>
 				</dict>
 			</array>
 			<key>INIntentResponse</key>
@@ -1434,7 +1417,7 @@
 			<key>INIntentKeyParameter</key>
 			<string>item</string>
 			<key>INIntentLastParameterTag</key>
-			<integer>6</integer>
+			<integer>7</integer>
 			<key>INIntentManagedParameterCombinations</key>
 			<dict>
 				<key>item,value,home</key>
@@ -1570,15 +1553,12 @@
 					<string>iBrALm</string>
 					<key>INIntentParameterDisplayPriority</key>
 					<integer>3</integer>
-					<key>INIntentParameterMetadata</key>
-					<dict>
-						<key>INIntentParameterMetadataCapitalization</key>
-						<string>Sentences</string>
-						<key>INIntentParameterMetadataDefaultValueID</key>
-						<string>6BeO57</string>
-					</dict>
 					<key>INIntentParameterName</key>
 					<string>home</string>
+					<key>INIntentParameterObjectType</key>
+					<string>Home</string>
+					<key>INIntentParameterObjectTypeNamespace</key>
+					<string>aK4nIm</string>
 					<key>INIntentParameterPromptDialogs</key>
 					<array>
 						<dict>
@@ -1633,9 +1613,9 @@
 					<key>INIntentParameterSupportsResolution</key>
 					<true/>
 					<key>INIntentParameterTag</key>
-					<integer>6</integer>
+					<integer>7</integer>
 					<key>INIntentParameterType</key>
-					<string>String</string>
+					<string>Object</string>
 				</dict>
 			</array>
 			<key>INIntentResponse</key>
@@ -1730,7 +1710,7 @@
 			<key>INIntentKeyParameter</key>
 			<string>item</string>
 			<key>INIntentLastParameterTag</key>
-			<integer>3</integer>
+			<integer>4</integer>
 			<key>INIntentManagedParameterCombinations</key>
 			<dict>
 				<key>item,state,home</key>
@@ -1864,15 +1844,12 @@
 					<string>7GA2x6</string>
 					<key>INIntentParameterDisplayPriority</key>
 					<integer>3</integer>
-					<key>INIntentParameterMetadata</key>
-					<dict>
-						<key>INIntentParameterMetadataCapitalization</key>
-						<string>Sentences</string>
-						<key>INIntentParameterMetadataDefaultValueID</key>
-						<string>6BeO57</string>
-					</dict>
 					<key>INIntentParameterName</key>
 					<string>home</string>
+					<key>INIntentParameterObjectType</key>
+					<string>Home</string>
+					<key>INIntentParameterObjectTypeNamespace</key>
+					<string>aK4nIm</string>
 					<key>INIntentParameterPromptDialogs</key>
 					<array>
 						<dict>
@@ -1927,9 +1904,9 @@
 					<key>INIntentParameterSupportsResolution</key>
 					<true/>
 					<key>INIntentParameterTag</key>
-					<integer>3</integer>
+					<integer>4</integer>
 					<key>INIntentParameterType</key>
-					<string>String</string>
+					<string>Object</string>
 				</dict>
 			</array>
 			<key>INIntentResponse</key>
@@ -2012,6 +1989,72 @@
 		</dict>
 	</array>
 	<key>INTypes</key>
-	<array/>
+	<array>
+		<dict>
+			<key>INTypeClassPrefix</key>
+			<string>OpenHAB</string>
+			<key>INTypeDisplayName</key>
+			<string>Home</string>
+			<key>INTypeDisplayNameID</key>
+			<string>zV2TH2</string>
+			<key>INTypeLastPropertyTag</key>
+			<integer>100</integer>
+			<key>INTypeName</key>
+			<string>Home</string>
+			<key>INTypeProperties</key>
+			<array>
+				<dict>
+					<key>INTypePropertyDefault</key>
+					<true/>
+					<key>INTypePropertyDisplayPriority</key>
+					<integer>1</integer>
+					<key>INTypePropertyName</key>
+					<string>identifier</string>
+					<key>INTypePropertyTag</key>
+					<integer>1</integer>
+					<key>INTypePropertyType</key>
+					<string>String</string>
+				</dict>
+				<dict>
+					<key>INTypePropertyDefault</key>
+					<true/>
+					<key>INTypePropertyDisplayPriority</key>
+					<integer>2</integer>
+					<key>INTypePropertyName</key>
+					<string>displayString</string>
+					<key>INTypePropertyTag</key>
+					<integer>2</integer>
+					<key>INTypePropertyType</key>
+					<string>String</string>
+				</dict>
+				<dict>
+					<key>INTypePropertyDefault</key>
+					<true/>
+					<key>INTypePropertyDisplayPriority</key>
+					<integer>3</integer>
+					<key>INTypePropertyName</key>
+					<string>pronunciationHint</string>
+					<key>INTypePropertyTag</key>
+					<integer>3</integer>
+					<key>INTypePropertyType</key>
+					<string>String</string>
+				</dict>
+				<dict>
+					<key>INTypePropertyDefault</key>
+					<true/>
+					<key>INTypePropertyDisplayPriority</key>
+					<integer>4</integer>
+					<key>INTypePropertyName</key>
+					<string>alternativeSpeakableMatches</string>
+					<key>INTypePropertySupportsMultipleValues</key>
+					<true/>
+					<key>INTypePropertyTag</key>
+					<integer>4</integer>
+					<key>INTypePropertyType</key>
+					<string>SpeakableString</string>
+				</dict>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/openHAB/Resources/Base.lproj/Intents.intentdefinition
+++ b/openHAB/Resources/Base.lproj/Intents.intentdefinition
@@ -9,11 +9,11 @@
 	<key>INIntentDefinitionNamespace</key>
 	<string>aK4nIm</string>
 	<key>INIntentDefinitionSystemVersion</key>
-	<string>21C52</string>
+	<string>24F74</string>
 	<key>INIntentDefinitionToolsBuildVersion</key>
-	<string>13C100</string>
+	<string>16F6</string>
 	<key>INIntentDefinitionToolsVersion</key>
-	<string>13.2.1</string>
+	<string>16.4</string>
 	<key>INIntents</key>
 	<array>
 		<dict>
@@ -32,10 +32,10 @@
 			<key>INIntentKeyParameter</key>
 			<string>item</string>
 			<key>INIntentLastParameterTag</key>
-			<integer>1</integer>
+			<integer>4</integer>
 			<key>INIntentManagedParameterCombinations</key>
 			<dict>
-				<key>item</key>
+				<key>item,home</key>
 				<dict>
 					<key>INIntentParameterCombinationSupportsBackgroundExecution</key>
 					<true/>
@@ -92,6 +92,90 @@
 					<true/>
 					<key>INIntentParameterTag</key>
 					<integer>1</integer>
+					<key>INIntentParameterType</key>
+					<string>String</string>
+				</dict>
+				<dict>
+					<key>INIntentParameterConfigurable</key>
+					<true/>
+					<key>INIntentParameterCustomDisambiguation</key>
+					<true/>
+					<key>INIntentParameterDisplayName</key>
+					<string>home</string>
+					<key>INIntentParameterDisplayNameID</key>
+					<string>k6pj4o</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>2</integer>
+					<key>INIntentParameterMetadata</key>
+					<dict>
+						<key>INIntentParameterMetadataCapitalization</key>
+						<string>Sentences</string>
+						<key>INIntentParameterMetadataDefaultValue</key>
+						<string>"asdf"</string>
+						<key>INIntentParameterMetadataDefaultValueID</key>
+						<string>6BeO57</string>
+					</dict>
+					<key>INIntentParameterName</key>
+					<string>home</string>
+					<key>INIntentParameterPromptDialogs</key>
+					<array>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>Home name</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>P9kblb</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Configuration</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>blabla</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>rsrXB9</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Primary</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>There are ${count} configured homes with an item named '${item}'’.</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>7BE642</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>DisambiguationIntroduction</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>For which home do you want to get the value?</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>4WCzFG</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>DisambiguationSelection</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>Just to confirm, you wanted ‘${home}’?</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>iKSmqU</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Confirmation</string>
+						</dict>
+					</array>
+					<key>INIntentParameterSupportsDynamicEnumeration</key>
+					<true/>
+					<key>INIntentParameterSupportsResolution</key>
+					<true/>
+					<key>INIntentParameterTag</key>
+					<integer>4</integer>
 					<key>INIntentParameterType</key>
 					<string>String</string>
 				</dict>
@@ -178,10 +262,10 @@
 			<key>INIntentKeyParameter</key>
 			<string>item</string>
 			<key>INIntentLastParameterTag</key>
-			<integer>2</integer>
+			<integer>3</integer>
 			<key>INIntentManagedParameterCombinations</key>
 			<dict>
-				<key>item,action</key>
+				<key>item,action,home</key>
 				<dict>
 					<key>INIntentParameterCombinationSupportsBackgroundExecution</key>
 					<true/>
@@ -197,16 +281,18 @@
 			<string>SetSwitchState</string>
 			<key>INIntentParameterCombinations</key>
 			<dict>
-				<key>item,action</key>
+				<key>item,action,home</key>
 				<dict>
 					<key>INIntentParameterCombinationIsLinked</key>
+					<true/>
+					<key>INIntentParameterCombinationIsPrimary</key>
 					<true/>
 					<key>INIntentParameterCombinationSupportsBackgroundExecution</key>
 					<true/>
 					<key>INIntentParameterCombinationTitle</key>
 					<string>Send ${action} to ${item}</string>
 					<key>INIntentParameterCombinationTitleID</key>
-					<string>IpbXHW</string>
+					<string>jyXazc</string>
 				</dict>
 			</dict>
 			<key>INIntentParameters</key>
@@ -296,6 +382,84 @@
 					<true/>
 					<key>INIntentParameterTag</key>
 					<integer>2</integer>
+					<key>INIntentParameterType</key>
+					<string>String</string>
+				</dict>
+				<dict>
+					<key>INIntentParameterConfigurable</key>
+					<true/>
+					<key>INIntentParameterCustomDisambiguation</key>
+					<true/>
+					<key>INIntentParameterDisplayName</key>
+					<string>home</string>
+					<key>INIntentParameterDisplayNameID</key>
+					<string>X9cN9h</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>3</integer>
+					<key>INIntentParameterMetadata</key>
+					<dict>
+						<key>INIntentParameterMetadataCapitalization</key>
+						<string>Sentences</string>
+						<key>INIntentParameterMetadataDefaultValueID</key>
+						<string>6BeO57</string>
+					</dict>
+					<key>INIntentParameterName</key>
+					<string>home</string>
+					<key>INIntentParameterPromptDialogs</key>
+					<array>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>Home name</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>v3hsWV</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Configuration</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Primary</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>There are ${count} configured homes with an item named '${item}'’.</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>YUoeAL</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>DisambiguationIntroduction</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>For which home do you want to get the value?</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>h91G9C</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>DisambiguationSelection</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>Just to confirm, you wanted ‘${home}’?</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>Jn2aNw</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Confirmation</string>
+						</dict>
+					</array>
+					<key>INIntentParameterSupportsDynamicEnumeration</key>
+					<true/>
+					<key>INIntentParameterSupportsResolution</key>
+					<true/>
+					<key>INIntentParameterTag</key>
+					<integer>3</integer>
 					<key>INIntentParameterType</key>
 					<string>String</string>
 				</dict>
@@ -392,10 +556,10 @@
 			<key>INIntentKeyParameter</key>
 			<string>item</string>
 			<key>INIntentLastParameterTag</key>
-			<integer>3</integer>
+			<integer>4</integer>
 			<key>INIntentManagedParameterCombinations</key>
 			<dict>
-				<key>item,value</key>
+				<key>item,value,home</key>
 				<dict>
 					<key>INIntentParameterCombinationSupportsBackgroundExecution</key>
 					<true/>
@@ -411,16 +575,18 @@
 			<string>SetDimmerRollerValue</string>
 			<key>INIntentParameterCombinations</key>
 			<dict>
-				<key>item,value</key>
+				<key>item,value,home</key>
 				<dict>
 					<key>INIntentParameterCombinationIsLinked</key>
+					<true/>
+					<key>INIntentParameterCombinationIsPrimary</key>
 					<true/>
 					<key>INIntentParameterCombinationSupportsBackgroundExecution</key>
 					<true/>
 					<key>INIntentParameterCombinationTitle</key>
 					<string>Set ${item} to ${value}</string>
 					<key>INIntentParameterCombinationTitleID</key>
-					<string>Cdg015</string>
+					<string>Ch9Akw</string>
 				</dict>
 			</dict>
 			<key>INIntentParameters</key>
@@ -506,6 +672,84 @@
 					<integer>3</integer>
 					<key>INIntentParameterType</key>
 					<string>Integer</string>
+				</dict>
+				<dict>
+					<key>INIntentParameterConfigurable</key>
+					<true/>
+					<key>INIntentParameterCustomDisambiguation</key>
+					<true/>
+					<key>INIntentParameterDisplayName</key>
+					<string>home</string>
+					<key>INIntentParameterDisplayNameID</key>
+					<string>ZuBsOg</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>3</integer>
+					<key>INIntentParameterMetadata</key>
+					<dict>
+						<key>INIntentParameterMetadataCapitalization</key>
+						<string>Sentences</string>
+						<key>INIntentParameterMetadataDefaultValueID</key>
+						<string>6BeO57</string>
+					</dict>
+					<key>INIntentParameterName</key>
+					<string>home</string>
+					<key>INIntentParameterPromptDialogs</key>
+					<array>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>Home name</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>rVXwR2</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Configuration</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Primary</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>There are ${count} configured homes with an item named '${item}'’.</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>BaNYuS</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>DisambiguationIntroduction</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>For which home do you want to get the value?</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>QATq1i</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>DisambiguationSelection</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>Just to confirm, you wanted ‘${home}’?</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>exrmKW</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Confirmation</string>
+						</dict>
+					</array>
+					<key>INIntentParameterSupportsDynamicEnumeration</key>
+					<true/>
+					<key>INIntentParameterSupportsResolution</key>
+					<true/>
+					<key>INIntentParameterTag</key>
+					<integer>4</integer>
+					<key>INIntentParameterType</key>
+					<string>String</string>
 				</dict>
 			</array>
 			<key>INIntentResponse</key>
@@ -608,10 +852,10 @@
 			<key>INIntentKeyParameter</key>
 			<string>item</string>
 			<key>INIntentLastParameterTag</key>
-			<integer>4</integer>
+			<integer>5</integer>
 			<key>INIntentManagedParameterCombinations</key>
 			<dict>
-				<key>item,value</key>
+				<key>item,value,home</key>
 				<dict>
 					<key>INIntentParameterCombinationSupportsBackgroundExecution</key>
 					<true/>
@@ -627,16 +871,18 @@
 			<string>SetNumberValue</string>
 			<key>INIntentParameterCombinations</key>
 			<dict>
-				<key>item,value</key>
+				<key>item,value,home</key>
 				<dict>
 					<key>INIntentParameterCombinationIsLinked</key>
+					<true/>
+					<key>INIntentParameterCombinationIsPrimary</key>
 					<true/>
 					<key>INIntentParameterCombinationSupportsBackgroundExecution</key>
 					<true/>
 					<key>INIntentParameterCombinationTitle</key>
 					<string>Set ${item} to ${value}</string>
 					<key>INIntentParameterCombinationTitleID</key>
-					<string>Gjd9MH</string>
+					<string>qYPBPC</string>
 				</dict>
 			</dict>
 			<key>INIntentParameters</key>
@@ -722,6 +968,84 @@
 					<integer>4</integer>
 					<key>INIntentParameterType</key>
 					<string>Decimal</string>
+				</dict>
+				<dict>
+					<key>INIntentParameterConfigurable</key>
+					<true/>
+					<key>INIntentParameterCustomDisambiguation</key>
+					<true/>
+					<key>INIntentParameterDisplayName</key>
+					<string>home</string>
+					<key>INIntentParameterDisplayNameID</key>
+					<string>zLlY3g</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>3</integer>
+					<key>INIntentParameterMetadata</key>
+					<dict>
+						<key>INIntentParameterMetadataCapitalization</key>
+						<string>Sentences</string>
+						<key>INIntentParameterMetadataDefaultValueID</key>
+						<string>6BeO57</string>
+					</dict>
+					<key>INIntentParameterName</key>
+					<string>home</string>
+					<key>INIntentParameterPromptDialogs</key>
+					<array>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>Home name</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>IS2nO0</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Configuration</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Primary</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>There are ${count} configured homes with an item named '${item}'’.</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>lLFYtM</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>DisambiguationIntroduction</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>For which home do you want to get the value?</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>jbUbYw</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>DisambiguationSelection</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>Just to confirm, you wanted ‘${home}’?</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>VEApie</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Confirmation</string>
+						</dict>
+					</array>
+					<key>INIntentParameterSupportsDynamicEnumeration</key>
+					<true/>
+					<key>INIntentParameterSupportsResolution</key>
+					<true/>
+					<key>INIntentParameterTag</key>
+					<integer>5</integer>
+					<key>INIntentParameterType</key>
+					<string>String</string>
 				</dict>
 			</array>
 			<key>INIntentResponse</key>
@@ -816,10 +1140,10 @@
 			<key>INIntentKeyParameter</key>
 			<string>item</string>
 			<key>INIntentLastParameterTag</key>
-			<integer>5</integer>
+			<integer>6</integer>
 			<key>INIntentManagedParameterCombinations</key>
 			<dict>
-				<key>item,value</key>
+				<key>item,value,home</key>
 				<dict>
 					<key>INIntentParameterCombinationSupportsBackgroundExecution</key>
 					<true/>
@@ -835,16 +1159,18 @@
 			<string>SetStringValue</string>
 			<key>INIntentParameterCombinations</key>
 			<dict>
-				<key>item,value</key>
+				<key>item,value,home</key>
 				<dict>
 					<key>INIntentParameterCombinationIsLinked</key>
+					<true/>
+					<key>INIntentParameterCombinationIsPrimary</key>
 					<true/>
 					<key>INIntentParameterCombinationSupportsBackgroundExecution</key>
 					<true/>
 					<key>INIntentParameterCombinationTitle</key>
 					<string>Set ${item} to ${value}</string>
 					<key>INIntentParameterCombinationTitleID</key>
-					<string>EEj00Q</string>
+					<string>1cBKdm</string>
 				</dict>
 			</dict>
 			<key>INIntentParameters</key>
@@ -934,6 +1260,84 @@
 					</array>
 					<key>INIntentParameterTag</key>
 					<integer>5</integer>
+					<key>INIntentParameterType</key>
+					<string>String</string>
+				</dict>
+				<dict>
+					<key>INIntentParameterConfigurable</key>
+					<true/>
+					<key>INIntentParameterCustomDisambiguation</key>
+					<true/>
+					<key>INIntentParameterDisplayName</key>
+					<string>home</string>
+					<key>INIntentParameterDisplayNameID</key>
+					<string>71MWtI</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>3</integer>
+					<key>INIntentParameterMetadata</key>
+					<dict>
+						<key>INIntentParameterMetadataCapitalization</key>
+						<string>Sentences</string>
+						<key>INIntentParameterMetadataDefaultValueID</key>
+						<string>6BeO57</string>
+					</dict>
+					<key>INIntentParameterName</key>
+					<string>home</string>
+					<key>INIntentParameterPromptDialogs</key>
+					<array>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>Home name</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>YFIIBn</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Configuration</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Primary</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>There are ${count} configured homes with an item named '${item}'’.</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>MIqlld</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>DisambiguationIntroduction</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>For which home do you want to get the value?</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>3LMXV8</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>DisambiguationSelection</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>Just to confirm, you wanted ‘${home}’?</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>gobcZi</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Confirmation</string>
+						</dict>
+					</array>
+					<key>INIntentParameterSupportsDynamicEnumeration</key>
+					<true/>
+					<key>INIntentParameterSupportsResolution</key>
+					<true/>
+					<key>INIntentParameterTag</key>
+					<integer>6</integer>
 					<key>INIntentParameterType</key>
 					<string>String</string>
 				</dict>
@@ -1030,10 +1434,10 @@
 			<key>INIntentKeyParameter</key>
 			<string>item</string>
 			<key>INIntentLastParameterTag</key>
-			<integer>5</integer>
+			<integer>6</integer>
 			<key>INIntentManagedParameterCombinations</key>
 			<dict>
-				<key>item,value</key>
+				<key>item,value,home</key>
 				<dict>
 					<key>INIntentParameterCombinationSupportsBackgroundExecution</key>
 					<true/>
@@ -1049,16 +1453,18 @@
 			<string>SetColorValue</string>
 			<key>INIntentParameterCombinations</key>
 			<dict>
-				<key>item,value</key>
+				<key>item,value,home</key>
 				<dict>
 					<key>INIntentParameterCombinationIsLinked</key>
+					<true/>
+					<key>INIntentParameterCombinationIsPrimary</key>
 					<true/>
 					<key>INIntentParameterCombinationSupportsBackgroundExecution</key>
 					<true/>
 					<key>INIntentParameterCombinationTitle</key>
 					<string>Set ${item} to ${value} (HSB)</string>
 					<key>INIntentParameterCombinationTitleID</key>
-					<string>1SeS3V</string>
+					<string>E07xjp</string>
 				</dict>
 			</dict>
 			<key>INIntentParameters</key>
@@ -1150,6 +1556,84 @@
 					</array>
 					<key>INIntentParameterTag</key>
 					<integer>5</integer>
+					<key>INIntentParameterType</key>
+					<string>String</string>
+				</dict>
+				<dict>
+					<key>INIntentParameterConfigurable</key>
+					<true/>
+					<key>INIntentParameterCustomDisambiguation</key>
+					<true/>
+					<key>INIntentParameterDisplayName</key>
+					<string>home</string>
+					<key>INIntentParameterDisplayNameID</key>
+					<string>iBrALm</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>3</integer>
+					<key>INIntentParameterMetadata</key>
+					<dict>
+						<key>INIntentParameterMetadataCapitalization</key>
+						<string>Sentences</string>
+						<key>INIntentParameterMetadataDefaultValueID</key>
+						<string>6BeO57</string>
+					</dict>
+					<key>INIntentParameterName</key>
+					<string>home</string>
+					<key>INIntentParameterPromptDialogs</key>
+					<array>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>Home name</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>eFNxrT</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Configuration</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Primary</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>There are ${count} configured homes with an item named '${item}'’.</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>jP4VSa</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>DisambiguationIntroduction</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>For which home do you want to get the value?</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>mHbznY</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>DisambiguationSelection</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>Just to confirm, you wanted ‘${home}’?</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>tkWfxz</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Confirmation</string>
+						</dict>
+					</array>
+					<key>INIntentParameterSupportsDynamicEnumeration</key>
+					<true/>
+					<key>INIntentParameterSupportsResolution</key>
+					<true/>
+					<key>INIntentParameterTag</key>
+					<integer>6</integer>
 					<key>INIntentParameterType</key>
 					<string>String</string>
 				</dict>
@@ -1246,10 +1730,10 @@
 			<key>INIntentKeyParameter</key>
 			<string>item</string>
 			<key>INIntentLastParameterTag</key>
-			<integer>2</integer>
+			<integer>3</integer>
 			<key>INIntentManagedParameterCombinations</key>
 			<dict>
-				<key>item,state</key>
+				<key>item,state,home</key>
 				<dict>
 					<key>INIntentParameterCombinationSupportsBackgroundExecution</key>
 					<true/>
@@ -1265,16 +1749,18 @@
 			<string>SetContactStateValue</string>
 			<key>INIntentParameterCombinations</key>
 			<dict>
-				<key>item,state</key>
+				<key>item,state,home</key>
 				<dict>
 					<key>INIntentParameterCombinationIsLinked</key>
+					<true/>
+					<key>INIntentParameterCombinationIsPrimary</key>
 					<true/>
 					<key>INIntentParameterCombinationSupportsBackgroundExecution</key>
 					<true/>
 					<key>INIntentParameterCombinationTitle</key>
 					<string>Set the state of ${item} to ${state}</string>
 					<key>INIntentParameterCombinationTitleID</key>
-					<string>qu9K9v</string>
+					<string>WsMKz2</string>
 				</dict>
 			</dict>
 			<key>INIntentParameters</key>
@@ -1364,6 +1850,84 @@
 					<true/>
 					<key>INIntentParameterTag</key>
 					<integer>2</integer>
+					<key>INIntentParameterType</key>
+					<string>String</string>
+				</dict>
+				<dict>
+					<key>INIntentParameterConfigurable</key>
+					<true/>
+					<key>INIntentParameterCustomDisambiguation</key>
+					<true/>
+					<key>INIntentParameterDisplayName</key>
+					<string>home</string>
+					<key>INIntentParameterDisplayNameID</key>
+					<string>7GA2x6</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>3</integer>
+					<key>INIntentParameterMetadata</key>
+					<dict>
+						<key>INIntentParameterMetadataCapitalization</key>
+						<string>Sentences</string>
+						<key>INIntentParameterMetadataDefaultValueID</key>
+						<string>6BeO57</string>
+					</dict>
+					<key>INIntentParameterName</key>
+					<string>home</string>
+					<key>INIntentParameterPromptDialogs</key>
+					<array>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>Home name</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>Ncumus</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Configuration</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Primary</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>There are ${count} configured homes with an item named '${item}'’.</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>H2V4UV</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>DisambiguationIntroduction</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>For which home do you want to get the value?</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>9Pu17E</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>DisambiguationSelection</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>Just to confirm, you wanted ‘${home}’?</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>0hYnWM</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Confirmation</string>
+						</dict>
+					</array>
+					<key>INIntentParameterSupportsDynamicEnumeration</key>
+					<true/>
+					<key>INIntentParameterSupportsResolution</key>
+					<true/>
+					<key>INIntentParameterTag</key>
+					<integer>3</integer>
 					<key>INIntentParameterType</key>
 					<string>String</string>
 				</dict>

--- a/openHABIntents/GetItemStateIntentHandler.swift
+++ b/openHABIntents/GetItemStateIntentHandler.swift
@@ -15,6 +15,8 @@ import OpenHABCore
 import os.log
 
 class GetItemStateIntentHandler: NSObject, OpenHABGetItemStateIntentHandling {
+    private let logger = Logger(subsystem: "org.openhab.app", category: "GetItemStateIntent")
+
     func resolveHome(for intent: OpenHABGetItemStateIntent) async -> INStringResolutionResult {
         // TODO: better (fuzzy?) resolution of home name
         logger.info("Resolving home for intent: \(intent)")
@@ -25,20 +27,12 @@ class GetItemStateIntentHandler: NSObject, OpenHABGetItemStateIntentHandling {
         INObjectCollection(items: Preferences.storedHomes.map(\.value.homeName).map { $0 as NSString })
     }
 
-    private let logger = Logger(subsystem: "org.openhab.app", category: "GetItemStateIntent")
-    private let itemCache: OpenHABItemCache
-
-    init(itemCache: OpenHABItemCache = OpenHABItemCache.instance) {
-        self.itemCache = itemCache
-    }
-
     func provideItemOptionsCollection(for intent: OpenHABGetItemStateIntent, searchTerm: String?) async throws -> INObjectCollection<NSString> {
-        let items = await itemCache.getAllCachedItems().flatMap(\.value).filtered(by: searchTerm)
-        return INObjectCollection(items: items.map(\.name).map { $0 as NSString })
+        await OpenHABIntentHelper.getItemOptions(home: intent.home, searchTerm: searchTerm)
     }
 
     func provideItemOptionsCollection(for intent: OpenHABGetItemStateIntent) async throws -> INObjectCollection<NSString> {
-        let items = await itemCache.getAllCachedItems().flatMap(\.value)
+        let items = await OpenHABIntentHelper.getItemOptions(home: intent.home)
         return INObjectCollection(items: items.map(\.name).map { $0 as NSString })
     }
 
@@ -55,12 +49,12 @@ class GetItemStateIntentHandler: NSObject, OpenHABGetItemStateIntentHandling {
             )
         }
 
-        let homeIds = Preferences.storedHomes.values.filter { $0.homeName == homeName }.map(\.id)
-        guard homeIds.count == 1 else {
+        let homeId = Preferences.firstStoredHome { $0.homeName == homeName }.map(\.id)
+        guard let homeId else {
             return .failureInvalidItem(NSLocalizedString("unknownHome", comment: "unknown home"))
         }
 
-        let items = await itemCache.getCachedItem(name: itemName, home: homeIds[0])
+        let items = await OpenHABItemCache.instance.getCachedItem(name: itemName, home: homeId)
 
         guard let items, items.count == 1 else {
             return .failureInvalidItem(itemName)
@@ -68,7 +62,7 @@ class GetItemStateIntentHandler: NSObject, OpenHABGetItemStateIntentHandling {
 
         return .success(
             item: itemName,
-            state: items[0].state ?? NSLocalizedString("unknown", comment: "unknown item")
+            state: items[0].state ?? NSLocalizedString("unknownState", comment: "unknown item state")
         )
     }
 }

--- a/openHABIntents/GetItemStateIntentHandler.swift
+++ b/openHABIntents/GetItemStateIntentHandler.swift
@@ -16,13 +16,12 @@ import os.log
 
 class GetItemStateIntentHandler: NSObject, OpenHABGetItemStateIntentHandling {
     func resolveHome(for intent: OpenHABGetItemStateIntent) async -> INStringResolutionResult {
-        // TODO:
+        // TODO: better (fuzzy?) resolution of home name
         INStringResolutionResult.success(with: intent.home ?? "Home")
     }
 
     func provideHomeOptionsCollection(for intent: OpenHABGetItemStateIntent) async throws -> INObjectCollection<NSString> {
-        // TODO:
-        INObjectCollection(items: ["Home", "Lehmgrubenweg"])
+        await INObjectCollection(items: Preferences.storedHomes.map(\.value.homeName).map { $0 as NSString })
     }
 
     private let logger = Logger(subsystem: "org.openhab.app", category: "GetItemStateIntent")

--- a/openHABIntents/GetItemStateIntentHandler.swift
+++ b/openHABIntents/GetItemStateIntentHandler.swift
@@ -17,28 +17,29 @@ import os.log
 class GetItemStateIntentHandler: NSObject, OpenHABGetItemStateIntentHandling {
     func resolveHome(for intent: OpenHABGetItemStateIntent) async -> INStringResolutionResult {
         // TODO: better (fuzzy?) resolution of home name
-        INStringResolutionResult.success(with: intent.home ?? "Home")
+        logger.info("Resolving home for intent: \(intent)")
+        return await OpenHABIntentHelper.resolveHome(home: intent.home, item: intent.item)
     }
 
     func provideHomeOptionsCollection(for intent: OpenHABGetItemStateIntent) async throws -> INObjectCollection<NSString> {
-        await INObjectCollection(items: Preferences.storedHomes.map(\.value.homeName).map { $0 as NSString })
+        INObjectCollection(items: Preferences.storedHomes.map(\.value.homeName).map { $0 as NSString })
     }
 
     private let logger = Logger(subsystem: "org.openhab.app", category: "GetItemStateIntent")
-    private let itemCache: any ItemCacheProtocol
+    private let itemCache: OpenHABItemCache
 
-    init(itemCache: any ItemCacheProtocol = OpenHABItemCache.instance) {
+    init(itemCache: OpenHABItemCache = OpenHABItemCache.instance) {
         self.itemCache = itemCache
     }
 
     func provideItemOptionsCollection(for intent: OpenHABGetItemStateIntent, searchTerm: String?) async throws -> INObjectCollection<NSString> {
-        let items = await itemCache.getItemNames(searchTerm: searchTerm, types: nil).map(NSString.init)
-        return INObjectCollection(items: items)
+        let items = await itemCache.getAllCachedItems().flatMap(\.value).filtered(by: searchTerm)
+        return INObjectCollection(items: items.map(\.name).map { $0 as NSString })
     }
 
     func provideItemOptionsCollection(for intent: OpenHABGetItemStateIntent) async throws -> INObjectCollection<NSString> {
-        let items = await itemCache.getItemNames(searchTerm: nil, types: nil).map(NSString.init)
-        return INObjectCollection(items: items)
+        let items = await itemCache.getAllCachedItems().flatMap(\.value)
+        return INObjectCollection(items: items.map(\.name).map { $0 as NSString })
     }
 
     func confirm(intent: OpenHABGetItemStateIntent) async -> OpenHABGetItemStateIntentResponse {
@@ -47,24 +48,27 @@ class GetItemStateIntentHandler: NSObject, OpenHABGetItemStateIntentHandling {
 
     func handle(intent: OpenHABGetItemStateIntent) async -> OpenHABGetItemStateIntentResponse {
         logger.info("GetItemStateIntent for \(intent.item ?? "")")
-        await OpenHABItemCache.instance.waitUntilReady()
-        // Proceed to fetch item and complete
 
-        guard let itemName = intent.item else {
+        guard let itemName = intent.item, let homeName = intent.home else {
             return .failureInvalidItem(
-                NSLocalizedString("empty", comment: "empty item name")
+                NSLocalizedString("empty", comment: "empty item / home name")
             )
         }
 
-        let item = await itemCache.getItem(name: itemName)
+        let homeIds = Preferences.storedHomes.values.filter { $0.homeName == homeName }.map(\.id)
+        guard homeIds.count == 1 else {
+            return .failureInvalidItem(NSLocalizedString("unknownHome", comment: "unknown home"))
+        }
 
-        guard let item else {
+        let items = await itemCache.getCachedItem(name: itemName, home: homeIds[0])
+
+        guard let items, items.count == 1 else {
             return .failureInvalidItem(itemName)
         }
 
         return .success(
             item: itemName,
-            state: item.state ?? NSLocalizedString("unknown", comment: "unknown item")
+            state: items[0].state ?? NSLocalizedString("unknown", comment: "unknown item")
         )
     }
 }

--- a/openHABIntents/GetItemStateIntentHandler.swift
+++ b/openHABIntents/GetItemStateIntentHandler.swift
@@ -15,6 +15,16 @@ import OpenHABCore
 import os.log
 
 class GetItemStateIntentHandler: NSObject, OpenHABGetItemStateIntentHandling {
+    func resolveHome(for intent: OpenHABGetItemStateIntent) async -> INStringResolutionResult {
+        // TODO:
+        INStringResolutionResult.success(with: intent.home ?? "Home")
+    }
+
+    func provideHomeOptionsCollection(for intent: OpenHABGetItemStateIntent) async throws -> INObjectCollection<NSString> {
+        // TODO:
+        INObjectCollection(items: ["Home", "Lehmgrubenweg"])
+    }
+
     private let logger = Logger(subsystem: "org.openhab.app", category: "GetItemStateIntent")
     private let itemCache: any ItemCacheProtocol
 

--- a/openHABIntents/GetItemStateIntentHandler.swift
+++ b/openHABIntents/GetItemStateIntentHandler.swift
@@ -18,13 +18,12 @@ class GetItemStateIntentHandler: NSObject, OpenHABGetItemStateIntentHandling {
     private let logger = Logger(subsystem: "org.openhab.app", category: "GetItemStateIntent")
 
     func resolveHome(for intent: OpenHABGetItemStateIntent) async -> INStringResolutionResult {
-        // TODO: better (fuzzy?) resolution of home name
         logger.info("Resolving home for intent: \(intent)")
         return await OpenHABIntentHelper.resolveHome(home: intent.home, item: intent.item)
     }
 
     func provideHomeOptionsCollection(for intent: OpenHABGetItemStateIntent) async throws -> INObjectCollection<NSString> {
-        INObjectCollection(items: Preferences.storedHomes.map(\.value.homeName).map { $0 as NSString })
+        OpenHABIntentHelper.getHomeOptions()
     }
 
     func provideItemOptionsCollection(for intent: OpenHABGetItemStateIntent, searchTerm: String?) async throws -> INObjectCollection<NSString> {
@@ -32,8 +31,7 @@ class GetItemStateIntentHandler: NSObject, OpenHABGetItemStateIntentHandling {
     }
 
     func provideItemOptionsCollection(for intent: OpenHABGetItemStateIntent) async throws -> INObjectCollection<NSString> {
-        let items = await OpenHABIntentHelper.getItemOptions(home: intent.home)
-        return INObjectCollection(items: items.map(\.name).map { $0 as NSString })
+        await OpenHABIntentHelper.getItemOptions(home: intent.home)
     }
 
     func confirm(intent: OpenHABGetItemStateIntent) async -> OpenHABGetItemStateIntentResponse {

--- a/openHABIntents/GetItemStateIntentHandler.swift
+++ b/openHABIntents/GetItemStateIntentHandler.swift
@@ -17,12 +17,12 @@ import os.log
 class GetItemStateIntentHandler: NSObject, OpenHABGetItemStateIntentHandling {
     private let logger = Logger(subsystem: "org.openhab.app", category: "GetItemStateIntent")
 
-    func resolveHome(for intent: OpenHABGetItemStateIntent) async -> INStringResolutionResult {
+    func resolveHome(for intent: OpenHABGetItemStateIntent) async -> OpenHABHomeResolutionResult {
         logger.info("Resolving home for intent: \(intent)")
         return await OpenHABIntentHelper.resolveHome(home: intent.home, item: intent.item)
     }
 
-    func provideHomeOptionsCollection(for intent: OpenHABGetItemStateIntent) async throws -> INObjectCollection<NSString> {
+    func provideHomeOptionsCollection(for intent: OpenHABGetItemStateIntent) async throws -> INObjectCollection<OpenHABHome> {
         OpenHABIntentHelper.getHomeOptions()
     }
 
@@ -41,14 +41,13 @@ class GetItemStateIntentHandler: NSObject, OpenHABGetItemStateIntentHandling {
     func handle(intent: OpenHABGetItemStateIntent) async -> OpenHABGetItemStateIntentResponse {
         logger.info("GetItemStateIntent for \(intent.item ?? "")")
 
-        guard let itemName = intent.item, let homeName = intent.home else {
+        guard let itemName = intent.item, let home = intent.home else {
             return .failureInvalidItem(
                 NSLocalizedString("empty", comment: "empty item / home name")
             )
         }
 
-        let homeId = Preferences.firstStoredHome { $0.homeName == homeName }.map(\.id)
-        guard let homeId else {
+        guard let homeId = home.uuid, Preferences.storedHomes[homeId] != nil else {
             return .failureInvalidItem(NSLocalizedString("unknownHome", comment: "unknown home"))
         }
 

--- a/openHABIntents/IntentHandler.swift
+++ b/openHABIntents/IntentHandler.swift
@@ -17,7 +17,7 @@ class IntentHandler: INExtension {
         super.init()
 
         Task {
-            await OpenHABItemCache.instance.setup()
+            await OpenHABItemCache.instance.forceCacheReload()
         }
     }
 

--- a/openHABIntents/OpenHABIntentHelper.swift
+++ b/openHABIntents/OpenHABIntentHelper.swift
@@ -1,0 +1,48 @@
+// Copyright (c) 2010-2025 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+import Foundation
+import Intents
+import OpenHABCore
+
+public enum OpenHABIntentHelper {
+    static func resolveHome(home: String?, item: String?) async -> INStringResolutionResult {
+        if let home {
+            // TODO: fuzzy matching / account for potential renaming?
+            // TODO: accept potential mismatches if item name is unique
+            let homeInPrefs = Preferences.storedHomes.values.map(\.homeName).filter { $0 == home }
+            if homeInPrefs.count == 1 {
+                return .success(with: home)
+            } else if homeInPrefs.count > 1 {
+                return .disambiguation(with: homeInPrefs)
+            } else {
+                return .unsupported() // given home is nowhere to be found
+            }
+        } else if let item {
+            // try to find the home by home-specific item selection
+            let allItems = await OpenHABItemCache.instance.getAllCachedItems()
+            let intentItems = allItems.map(\.key).filter { uuid in
+                allItems[uuid]?.filtered(by: item).isEmpty != true
+            }
+            let potentialHomeNames = intentItems.map { Preferences.storedHomes[$0]?.homeName }.filter { $0 != nil }.map { $0 ?? "" }
+            if potentialHomeNames.count == 1 {
+                guard let homeName = Preferences.storedHomes[intentItems[0]]?.homeName else {
+                    return .unsupported() // seems like we found an outdated cached item / home
+                }
+                return .success(with: homeName)
+            } else {
+                return .disambiguation(with: potentialHomeNames)
+            }
+        } else {
+            return .needsValue()
+        }
+    }
+}

--- a/openHABIntents/OpenHABIntentHelper.swift
+++ b/openHABIntents/OpenHABIntentHelper.swift
@@ -14,53 +14,60 @@ import Intents
 import OpenHABCore
 
 public enum OpenHABIntentHelper {
-    static func resolveHome(home: String?, item: String?) async -> INStringResolutionResult {
-        if let home {
+    static func resolveHome(home: OpenHABHome?, item: String?) async -> OpenHABHomeResolutionResult {
+        if let home, let homeId = home.uuid {
             // TODO: fuzzy matching / account for potential renaming?
             // TODO: accept potential mismatches if item name is unique
-            let homeInPrefs = Preferences.storedHomes.values.map(\.homeName).filter { $0 == home }
-            if homeInPrefs.count == 1 {
+            let homePrefs = Preferences.storedHomes.first { $0.key == homeId }
+            if homePrefs != nil {
                 return .success(with: home)
-            } else if homeInPrefs.count > 1 {
-                return .disambiguation(with: homeInPrefs)
             } else {
-                return .unsupported() // given home is nowhere to be found
+                return .unsupported() // given home is not found in preferences
             }
         } else if let item {
             // try to find the home by home-specific item selection
             let allItems = await OpenHABItemCache.instance.getAllCachedItems()
-            let intentItems = allItems.map(\.key).filter { uuid in
+            let homeIdsWithMatchingItems = allItems.map(\.key).filter { uuid in
                 allItems[uuid]?.filtered(by: item).isEmpty != true
             }
-            let potentialHomeNames = intentItems.map { Preferences.storedHomes[$0]?.homeName }.filter { $0 != nil }.map { $0 ?? "" }
-            if potentialHomeNames.count == 1 {
-                guard let homeName = Preferences.storedHomes[intentItems[0]]?.homeName else {
-                    return .unsupported() // seems like we found an outdated cached item / home
-                }
-                return .success(with: homeName)
+            let potentialHomes = homeIdsWithMatchingItems
+                .compactMap { Preferences.storedHomes[$0] }
+                .map { OpenHABHome(home: $0) }
+            if potentialHomes.count == 1 {
+                return .success(with: potentialHomes[0])
             } else {
-                return .disambiguation(with: potentialHomeNames)
+                return .disambiguation(with: potentialHomes)
             }
         } else {
             return .needsValue()
         }
     }
 
-    static func getHomeOptions() -> INObjectCollection<NSString> {
-        INObjectCollection(items: Preferences.storedHomes.map(\.value.homeName).map { $0 as NSString })
+    static func getHomeOptions() -> INObjectCollection<OpenHABHome> {
+        INObjectCollection(items: Preferences.storedHomes.map { OpenHABHome(home: $0.value) })
     }
 
-    static func getItemOptions(home: String?, searchTerm: String? = nil, itemTypes: [OpenHABItem.ItemType]? = nil) async -> INObjectCollection<NSString> {
+    static func getItemOptions(home: OpenHABHome?, searchTerm: String? = nil, itemTypes: [OpenHABItem.ItemType]? = nil) async -> INObjectCollection<NSString> {
         let allItems = await getAllItems(home: home)
         let items = allItems.filtered(by: searchTerm, for: itemTypes)
         return INObjectCollection(items: items.map(\.name).map { $0 as NSString })
     }
 
-    private static func getAllItems(home: String?) async -> [OpenHABItem] {
-        if let home, let homeId = Preferences.firstStoredHome(where: { $0.homeName == home })?.id {
+    private static func getAllItems(home: OpenHABHome?) async -> [OpenHABItem] {
+        if let home, let homeId = home.uuid {
             await OpenHABItemCache.instance.getCachedItems(home: homeId) ?? []
         } else {
             await OpenHABItemCache.instance.getAllCachedItems().flatMap(\.value)
         }
+    }
+}
+
+extension OpenHABHome {
+    var uuid: UUID? {
+        UUID(uuidString: identifier ?? "")
+    }
+
+    convenience init(home: HomePreferences) {
+        self.init(identifier: home.id.uuidString, display: home.homeName)
     }
 }

--- a/openHABIntents/OpenHABIntentHelper.swift
+++ b/openHABIntents/OpenHABIntentHelper.swift
@@ -46,13 +46,17 @@ public enum OpenHABIntentHelper {
         }
     }
 
-    static func getItemOptions(home: String?, searchTerm: String?) async -> INObjectCollection<NSString> {
-        let allItems = await getItemOptions(home: home)
-        let items = allItems.filtered(by: searchTerm)
+    static func getHomeOptions() -> INObjectCollection<NSString> {
+        INObjectCollection(items: Preferences.storedHomes.map(\.value.homeName).map { $0 as NSString })
+    }
+
+    static func getItemOptions(home: String?, searchTerm: String? = nil, itemTypes: [OpenHABItem.ItemType]? = nil) async -> INObjectCollection<NSString> {
+        let allItems = await getAllItems(home: home)
+        let items = allItems.filtered(by: searchTerm, for: itemTypes)
         return INObjectCollection(items: items.map(\.name).map { $0 as NSString })
     }
 
-    static func getItemOptions(home: String?) async -> [OpenHABItem] {
+    private static func getAllItems(home: String?) async -> [OpenHABItem] {
         if let home, let homeId = Preferences.firstStoredHome(where: { $0.homeName == home })?.id {
             await OpenHABItemCache.instance.getCachedItems(home: homeId) ?? []
         } else {

--- a/openHABIntents/OpenHABIntentHelper.swift
+++ b/openHABIntents/OpenHABIntentHelper.swift
@@ -45,4 +45,18 @@ public enum OpenHABIntentHelper {
             return .needsValue()
         }
     }
+
+    static func getItemOptions(home: String?, searchTerm: String?) async -> INObjectCollection<NSString> {
+        let allItems = await getItemOptions(home: home)
+        let items = allItems.filtered(by: searchTerm)
+        return INObjectCollection(items: items.map(\.name).map { $0 as NSString })
+    }
+
+    static func getItemOptions(home: String?) async -> [OpenHABItem] {
+        if let home, let homeId = Preferences.firstStoredHome(where: { $0.homeName == home })?.id {
+            await OpenHABItemCache.instance.getCachedItems(home: homeId) ?? []
+        } else {
+            await OpenHABItemCache.instance.getAllCachedItems().flatMap(\.value)
+        }
+    }
 }

--- a/openHABIntents/SetColorValueIntentHandler.swift
+++ b/openHABIntents/SetColorValueIntentHandler.swift
@@ -25,9 +25,9 @@ class SetColorValueIntentHandler: NSObject, OpenHABSetColorValueIntentHandling {
     }
 
     private let logger = Logger(subsystem: "org.openhab.app", category: "SetColorValueIntent")
-    private let itemCache: any ItemCacheProtocol
+    private let itemCache: OpenHABItemCache
 
-    init(itemCache: any ItemCacheProtocol = OpenHABItemCache.instance) {
+    init(itemCache: OpenHABItemCache = OpenHABItemCache.instance) {
         self.itemCache = itemCache
     }
 

--- a/openHABIntents/SetColorValueIntentHandler.swift
+++ b/openHABIntents/SetColorValueIntentHandler.swift
@@ -15,6 +15,16 @@ import OpenHABCore
 import os.log
 
 class SetColorValueIntentHandler: NSObject, OpenHABSetColorValueIntentHandling {
+    func resolveHome(for intent: OpenHABSetColorValueIntent) async -> INStringResolutionResult {
+        // TODO:
+        INStringResolutionResult.success(with: intent.home ?? "Home")
+    }
+
+    func provideHomeOptionsCollection(for intent: OpenHABSetColorValueIntent) async throws -> INObjectCollection<NSString> {
+        // TODO:
+        INObjectCollection(items: ["Home", "Lehmgrubenweg"])
+    }
+
     private let logger = Logger(subsystem: "org.openhab.app", category: "SetColorValueIntent")
     private let itemCache: any ItemCacheProtocol
 

--- a/openHABIntents/SetColorValueIntentHandler.swift
+++ b/openHABIntents/SetColorValueIntentHandler.swift
@@ -15,34 +15,23 @@ import OpenHABCore
 import os.log
 
 class SetColorValueIntentHandler: NSObject, OpenHABSetColorValueIntentHandling {
+    private let logger = Logger(subsystem: "org.openhab.app", category: "SetColorValueIntent")
+
     func resolveHome(for intent: OpenHABSetColorValueIntent) async -> INStringResolutionResult {
-        // TODO:
-        INStringResolutionResult.success(with: intent.home ?? "Home")
+        logger.info("Resolving home for intent: \(intent)")
+        return await OpenHABIntentHelper.resolveHome(home: intent.home, item: intent.item)
     }
 
     func provideHomeOptionsCollection(for intent: OpenHABSetColorValueIntent) async throws -> INObjectCollection<NSString> {
-        await INObjectCollection(items: Preferences.storedHomes.map(\.value.homeName).map { $0 as NSString })
-    }
-
-    private let logger = Logger(subsystem: "org.openhab.app", category: "SetColorValueIntent")
-    private let itemCache: OpenHABItemCache
-
-    init(itemCache: OpenHABItemCache = OpenHABItemCache.instance) {
-        self.itemCache = itemCache
+        OpenHABIntentHelper.getHomeOptions()
     }
 
     func provideItemOptionsCollection(for intent: OpenHABSetColorValueIntent, searchTerm: String?) async throws -> INObjectCollection<NSString> {
-        let items = await itemCache
-            .getItemNames(searchTerm: searchTerm, types: [.color])
-            .map(NSString.init)
-        return INObjectCollection(items: items)
+        await OpenHABIntentHelper.getItemOptions(home: intent.home, searchTerm: searchTerm, itemTypes: [.color])
     }
 
     func provideItemOptionsCollection(for intent: OpenHABSetColorValueIntent) async throws -> INObjectCollection<NSString> {
-        let items = await itemCache
-            .getItemNames(searchTerm: nil, types: [.color])
-            .map(NSString.init)
-        return INObjectCollection(items: items)
+        await OpenHABIntentHelper.getItemOptions(home: intent.home, itemTypes: [.color])
     }
 
     func confirm(intent: OpenHABSetColorValueIntent) async -> OpenHABSetColorValueIntentResponse {
@@ -52,10 +41,13 @@ class SetColorValueIntentHandler: NSObject, OpenHABSetColorValueIntentHandling {
     func handle(intent: OpenHABSetColorValueIntent) async -> OpenHABSetColorValueIntentResponse {
         logger.info("SetColorValueIntent for \(intent.item ?? "")")
 
-        await OpenHABItemCache.instance.waitUntilReady()
+        guard let itemName = intent.item, let homeName = intent.home else {
+            return .failureInvalidItem(NSLocalizedString("empty", comment: "empty item / home name"))
+        }
 
-        guard let itemName = intent.item else {
-            return .failureInvalidItem(NSLocalizedString("empty", comment: "empty item name"))
+        let homeId = Preferences.firstStoredHome { $0.homeName == homeName }.map(\.id)
+        guard let homeId else {
+            return .failureInvalidItem(NSLocalizedString("unknownHome", comment: "unknown home"))
         }
 
         guard var value = intent.value else {
@@ -75,11 +67,13 @@ class SetColorValueIntentHandler: NSObject, OpenHABSetColorValueIntentHandling {
 
         value = "\(hue),\(sat),\(val)"
 
-        guard let item = await itemCache.getItem(name: itemName) else {
+        guard let items = await OpenHABItemCache.instance.getCachedItem(name: itemName, home: homeId), !items.isEmpty else {
             return .failureInvalidItem(itemName)
         }
 
-        await itemCache.sendCommand(item, commandToSend: value)
+        let item = items[0]
+
+        await OpenHABItemCache.instance.sendCommand(to: item, home: homeId, command: value)
 
         return .success(value: value, item: itemName)
     }

--- a/openHABIntents/SetColorValueIntentHandler.swift
+++ b/openHABIntents/SetColorValueIntentHandler.swift
@@ -17,12 +17,12 @@ import os.log
 class SetColorValueIntentHandler: NSObject, OpenHABSetColorValueIntentHandling {
     private let logger = Logger(subsystem: "org.openhab.app", category: "SetColorValueIntent")
 
-    func resolveHome(for intent: OpenHABSetColorValueIntent) async -> INStringResolutionResult {
+    func resolveHome(for intent: OpenHABSetColorValueIntent) async -> OpenHABHomeResolutionResult {
         logger.info("Resolving home for intent: \(intent)")
         return await OpenHABIntentHelper.resolveHome(home: intent.home, item: intent.item)
     }
 
-    func provideHomeOptionsCollection(for intent: OpenHABSetColorValueIntent) async throws -> INObjectCollection<NSString> {
+    func provideHomeOptionsCollection(for intent: OpenHABSetColorValueIntent) async throws -> INObjectCollection<OpenHABHome> {
         OpenHABIntentHelper.getHomeOptions()
     }
 
@@ -41,12 +41,13 @@ class SetColorValueIntentHandler: NSObject, OpenHABSetColorValueIntentHandling {
     func handle(intent: OpenHABSetColorValueIntent) async -> OpenHABSetColorValueIntentResponse {
         logger.info("SetColorValueIntent for \(intent.item ?? "")")
 
-        guard let itemName = intent.item, let homeName = intent.home else {
-            return .failureInvalidItem(NSLocalizedString("empty", comment: "empty item / home name"))
+        guard let itemName = intent.item, let home = intent.home else {
+            return .failureInvalidItem(
+                NSLocalizedString("empty", comment: "empty item / home name")
+            )
         }
 
-        let homeId = Preferences.firstStoredHome { $0.homeName == homeName }.map(\.id)
-        guard let homeId else {
+        guard let homeId = home.uuid, Preferences.storedHomes[homeId] != nil else {
             return .failureInvalidItem(NSLocalizedString("unknownHome", comment: "unknown home"))
         }
 

--- a/openHABIntents/SetColorValueIntentHandler.swift
+++ b/openHABIntents/SetColorValueIntentHandler.swift
@@ -21,8 +21,7 @@ class SetColorValueIntentHandler: NSObject, OpenHABSetColorValueIntentHandling {
     }
 
     func provideHomeOptionsCollection(for intent: OpenHABSetColorValueIntent) async throws -> INObjectCollection<NSString> {
-        // TODO:
-        INObjectCollection(items: ["Home", "Lehmgrubenweg"])
+        await INObjectCollection(items: Preferences.storedHomes.map(\.value.homeName).map { $0 as NSString })
     }
 
     private let logger = Logger(subsystem: "org.openhab.app", category: "SetColorValueIntent")

--- a/openHABIntents/SetContactStateValueIntentHandler.swift
+++ b/openHABIntents/SetContactStateValueIntentHandler.swift
@@ -34,9 +34,9 @@ class SetContactStateValueIntentHandler: NSObject, OpenHABSetContactStateValueIn
     ]
 
     private let logger = Logger(subsystem: "org.openhab.app", category: "SetColorValueIntent")
-    private let itemCache: any ItemCacheProtocol
+    private let itemCache: OpenHABItemCache
 
-    init(itemCache: any ItemCacheProtocol = OpenHABItemCache.instance) {
+    init(itemCache: OpenHABItemCache = OpenHABItemCache.instance) {
         self.itemCache = itemCache
     }
 

--- a/openHABIntents/SetContactStateValueIntentHandler.swift
+++ b/openHABIntents/SetContactStateValueIntentHandler.swift
@@ -15,15 +15,6 @@ import OpenHABCore
 import os.log
 
 class SetContactStateValueIntentHandler: NSObject, OpenHABSetContactStateValueIntentHandling {
-    func resolveHome(for intent: OpenHABSetContactStateValueIntent) async -> INStringResolutionResult {
-        // TODO:
-        INStringResolutionResult.success(with: intent.home ?? "Home")
-    }
-
-    func provideHomeOptionsCollection(for intent: OpenHABSetContactStateValueIntent) async throws -> INObjectCollection<NSString> {
-        await INObjectCollection(items: Preferences.storedHomes.map(\.value.homeName).map { $0 as NSString })
-    }
-
     private static let onLabel = NSLocalizedString("on", comment: "").capitalized
     private static let offLabel = NSLocalizedString("off", comment: "").capitalized
 
@@ -34,10 +25,14 @@ class SetContactStateValueIntentHandler: NSObject, OpenHABSetContactStateValueIn
     ]
 
     private let logger = Logger(subsystem: "org.openhab.app", category: "SetColorValueIntent")
-    private let itemCache: OpenHABItemCache
 
-    init(itemCache: OpenHABItemCache = OpenHABItemCache.instance) {
-        self.itemCache = itemCache
+    func resolveHome(for intent: OpenHABSetContactStateValueIntent) async -> INStringResolutionResult {
+        logger.info("Resolving home for intent: \(intent)")
+        return await OpenHABIntentHelper.resolveHome(home: intent.home, item: intent.item)
+    }
+
+    func provideHomeOptionsCollection(for intent: OpenHABSetContactStateValueIntent) async throws -> INObjectCollection<NSString> {
+        OpenHABIntentHelper.getHomeOptions()
     }
 
     func provideStateOptionsCollection(for intent: OpenHABSetContactStateValueIntent) async throws -> INObjectCollection<NSString> {
@@ -45,17 +40,11 @@ class SetContactStateValueIntentHandler: NSObject, OpenHABSetContactStateValueIn
     }
 
     func provideItemOptionsCollection(for intent: OpenHABSetContactStateValueIntent, searchTerm: String?) async throws -> INObjectCollection<NSString> {
-        let items = await itemCache
-            .getItemNames(searchTerm: searchTerm, types: [.contact])
-            .map(NSString.init)
-        return INObjectCollection(items: items)
+        await OpenHABIntentHelper.getItemOptions(home: intent.home, searchTerm: searchTerm, itemTypes: [.contact])
     }
 
     func provideItemOptionsCollection(for intent: OpenHABSetContactStateValueIntent) async throws -> INObjectCollection<NSString> {
-        let items = await itemCache
-            .getItemNames(searchTerm: nil, types: [.contact])
-            .map(NSString.init)
-        return INObjectCollection(items: items)
+        await OpenHABIntentHelper.getItemOptions(home: intent.home, itemTypes: [.contact])
     }
 
     func confirm(intent: OpenHABSetContactStateValueIntent) async -> OpenHABSetContactStateValueIntentResponse {
@@ -65,10 +54,13 @@ class SetContactStateValueIntentHandler: NSObject, OpenHABSetContactStateValueIn
     func handle(intent: OpenHABSetContactStateValueIntent) async -> OpenHABSetContactStateValueIntentResponse {
         logger.info("SetContactStateValueIntent for \(intent.item ?? "")")
 
-        await OpenHABItemCache.instance.waitUntilReady()
+        guard let itemName = intent.item, let homeName = intent.home else {
+            return .failureInvalidItem(NSLocalizedString("empty", comment: "empty item / home name"))
+        }
 
-        guard let itemName = intent.item else {
-            return .failureInvalidItem(NSLocalizedString("empty", comment: "empty item name"))
+        let homeId = Preferences.firstStoredHome { $0.homeName == homeName }.map(\.id)
+        guard let homeId else {
+            return .failureInvalidItem(NSLocalizedString("unknownHome", comment: "unknown home"))
         }
 
         guard let state = intent.state else {
@@ -82,11 +74,13 @@ class SetContactStateValueIntentHandler: NSObject, OpenHABSetContactStateValueIn
             return .failureInvalidAction(state: state, item: itemName)
         }
 
-        guard let item = await itemCache.getItem(name: itemName) else {
+        guard let items = await OpenHABItemCache.instance.getCachedItem(name: itemName, home: homeId), !items.isEmpty else {
             return .failureInvalidItem(itemName)
         }
 
-        await itemCache.sendState(item, stateToSend: realState)
+        let item = items[0]
+
+        await OpenHABItemCache.instance.sendCommand(to: item, home: homeId, command: realState)
 
         return .success(item: itemName, state: state)
     }

--- a/openHABIntents/SetContactStateValueIntentHandler.swift
+++ b/openHABIntents/SetContactStateValueIntentHandler.swift
@@ -15,6 +15,16 @@ import OpenHABCore
 import os.log
 
 class SetContactStateValueIntentHandler: NSObject, OpenHABSetContactStateValueIntentHandling {
+    func resolveHome(for intent: OpenHABSetContactStateValueIntent) async -> INStringResolutionResult {
+        // TODO:
+        INStringResolutionResult.success(with: intent.home ?? "Home")
+    }
+
+    func provideHomeOptionsCollection(for intent: OpenHABSetContactStateValueIntent) async throws -> INObjectCollection<NSString> {
+        // TODO:
+        INObjectCollection(items: ["Home", "Lehmgrubenweg"])
+    }
+
     private static let onLabel = NSLocalizedString("on", comment: "").capitalized
     private static let offLabel = NSLocalizedString("off", comment: "").capitalized
 

--- a/openHABIntents/SetContactStateValueIntentHandler.swift
+++ b/openHABIntents/SetContactStateValueIntentHandler.swift
@@ -21,8 +21,7 @@ class SetContactStateValueIntentHandler: NSObject, OpenHABSetContactStateValueIn
     }
 
     func provideHomeOptionsCollection(for intent: OpenHABSetContactStateValueIntent) async throws -> INObjectCollection<NSString> {
-        // TODO:
-        INObjectCollection(items: ["Home", "Lehmgrubenweg"])
+        await INObjectCollection(items: Preferences.storedHomes.map(\.value.homeName).map { $0 as NSString })
     }
 
     private static let onLabel = NSLocalizedString("on", comment: "").capitalized

--- a/openHABIntents/SetContactStateValueIntentHandler.swift
+++ b/openHABIntents/SetContactStateValueIntentHandler.swift
@@ -26,12 +26,12 @@ class SetContactStateValueIntentHandler: NSObject, OpenHABSetContactStateValueIn
 
     private let logger = Logger(subsystem: "org.openhab.app", category: "SetColorValueIntent")
 
-    func resolveHome(for intent: OpenHABSetContactStateValueIntent) async -> INStringResolutionResult {
+    func resolveHome(for intent: OpenHABSetContactStateValueIntent) async -> OpenHABHomeResolutionResult {
         logger.info("Resolving home for intent: \(intent)")
         return await OpenHABIntentHelper.resolveHome(home: intent.home, item: intent.item)
     }
 
-    func provideHomeOptionsCollection(for intent: OpenHABSetContactStateValueIntent) async throws -> INObjectCollection<NSString> {
+    func provideHomeOptionsCollection(for intent: OpenHABSetContactStateValueIntent) async throws -> INObjectCollection<OpenHABHome> {
         OpenHABIntentHelper.getHomeOptions()
     }
 
@@ -54,12 +54,13 @@ class SetContactStateValueIntentHandler: NSObject, OpenHABSetContactStateValueIn
     func handle(intent: OpenHABSetContactStateValueIntent) async -> OpenHABSetContactStateValueIntentResponse {
         logger.info("SetContactStateValueIntent for \(intent.item ?? "")")
 
-        guard let itemName = intent.item, let homeName = intent.home else {
-            return .failureInvalidItem(NSLocalizedString("empty", comment: "empty item / home name"))
+        guard let itemName = intent.item, let home = intent.home else {
+            return .failureInvalidItem(
+                NSLocalizedString("empty", comment: "empty item / home name")
+            )
         }
 
-        let homeId = Preferences.firstStoredHome { $0.homeName == homeName }.map(\.id)
-        guard let homeId else {
+        guard let homeId = home.uuid, Preferences.storedHomes[homeId] != nil else {
             return .failureInvalidItem(NSLocalizedString("unknownHome", comment: "unknown home"))
         }
 

--- a/openHABIntents/SetDimmerRollerValueIntentHandler.swift
+++ b/openHABIntents/SetDimmerRollerValueIntentHandler.swift
@@ -25,9 +25,9 @@ class SetDimmerRollerValueIntentHandler: NSObject, OpenHABSetDimmerRollerValueIn
     }
 
     private let logger = Logger(subsystem: "org.openhab.app", category: "SetDimmerRollerValueIntent")
-    private let itemCache: any ItemCacheProtocol
+    private let itemCache: OpenHABItemCache
 
-    init(itemCache: any ItemCacheProtocol = OpenHABItemCache.instance) {
+    init(itemCache: OpenHABItemCache = OpenHABItemCache.instance) {
         self.itemCache = itemCache
     }
 

--- a/openHABIntents/SetDimmerRollerValueIntentHandler.swift
+++ b/openHABIntents/SetDimmerRollerValueIntentHandler.swift
@@ -15,39 +15,23 @@ import OpenHABCore
 import os.log
 
 class SetDimmerRollerValueIntentHandler: NSObject, OpenHABSetDimmerRollerValueIntentHandling {
+    private let logger = Logger(subsystem: "org.openhab.app", category: "SetDimmerRollerValueIntent")
+
     func resolveHome(for intent: OpenHABSetDimmerRollerValueIntent) async -> INStringResolutionResult {
-        // TODO:
-        INStringResolutionResult.success(with: intent.home ?? "Home")
+        logger.info("Resolving home for intent: \(intent)")
+        return await OpenHABIntentHelper.resolveHome(home: intent.home, item: intent.item)
     }
 
     func provideHomeOptionsCollection(for intent: OpenHABSetDimmerRollerValueIntent) async throws -> INObjectCollection<NSString> {
-        await INObjectCollection(items: Preferences.storedHomes.map(\.value.homeName).map { $0 as NSString })
-    }
-
-    private let logger = Logger(subsystem: "org.openhab.app", category: "SetDimmerRollerValueIntent")
-    private let itemCache: OpenHABItemCache
-
-    init(itemCache: OpenHABItemCache = OpenHABItemCache.instance) {
-        self.itemCache = itemCache
+        OpenHABIntentHelper.getHomeOptions()
     }
 
     func provideItemOptionsCollection(for intent: OpenHABSetDimmerRollerValueIntent, searchTerm: String?) async throws -> INObjectCollection<NSString> {
-        // TODO:
-        let items = await itemCache.getItemNames(
-            searchTerm: searchTerm,
-            types: [.dimmer, .rollershutter]
-        )
-        .map(NSString.init)
-        return INObjectCollection(items: items)
+        await OpenHABIntentHelper.getItemOptions(home: intent.home, searchTerm: searchTerm, itemTypes: [.dimmer, .rollershutter])
     }
 
     func provideItemOptionsCollection(for intent: OpenHABSetDimmerRollerValueIntent) async throws -> INObjectCollection<NSString> {
-        let items = await itemCache.getItemNames(
-            searchTerm: nil,
-            types: [.dimmer, .rollershutter]
-        )
-        .map(NSString.init)
-        return INObjectCollection(items: items)
+        await OpenHABIntentHelper.getItemOptions(home: intent.home, itemTypes: [.dimmer, .rollershutter])
     }
 
     func confirm(intent: OpenHABSetDimmerRollerValueIntent) async -> OpenHABSetDimmerRollerValueIntentResponse {
@@ -57,12 +41,13 @@ class SetDimmerRollerValueIntentHandler: NSObject, OpenHABSetDimmerRollerValueIn
     func handle(intent: OpenHABSetDimmerRollerValueIntent) async -> OpenHABSetDimmerRollerValueIntentResponse {
         logger.info("SetDimmerRollerValueIntent for \(intent.item ?? "")")
 
-        await OpenHABItemCache.instance.waitUntilReady()
+        guard let itemName = intent.item, let homeName = intent.home else {
+            return .failureInvalidItem(NSLocalizedString("empty", comment: "empty item / home name"))
+        }
 
-        guard let itemName = intent.item else {
-            return .failureInvalidItem(
-                NSLocalizedString("empty", comment: "empty item name")
-            )
+        let homeId = Preferences.firstStoredHome { $0.homeName == homeName }.map(\.id)
+        guard let homeId else {
+            return .failureInvalidItem(NSLocalizedString("unknownHome", comment: "unknown home"))
         }
 
         guard let value = intent.value else {
@@ -75,11 +60,13 @@ class SetDimmerRollerValueIntentHandler: NSObject, OpenHABSetDimmerRollerValueIn
             return .failureInvalidValue(value, item: itemName)
         }
 
-        guard let item = await itemCache.getItem(name: itemName) else {
+        guard let items = await OpenHABItemCache.instance.getCachedItem(name: itemName, home: homeId), !items.isEmpty else {
             return .failureInvalidItem(itemName)
         }
 
-        await itemCache.sendCommand(item, commandToSend: "\(number)")
+        let item = items[0]
+
+        await OpenHABItemCache.instance.sendCommand(to: item, home: homeId, command: "\(number)")
 
         return .success(value: NSNumber(value: number), item: itemName)
     }

--- a/openHABIntents/SetDimmerRollerValueIntentHandler.swift
+++ b/openHABIntents/SetDimmerRollerValueIntentHandler.swift
@@ -15,6 +15,16 @@ import OpenHABCore
 import os.log
 
 class SetDimmerRollerValueIntentHandler: NSObject, OpenHABSetDimmerRollerValueIntentHandling {
+    func resolveHome(for intent: OpenHABSetDimmerRollerValueIntent) async -> INStringResolutionResult {
+        // TODO:
+        INStringResolutionResult.success(with: intent.home ?? "Home")
+    }
+
+    func provideHomeOptionsCollection(for intent: OpenHABSetDimmerRollerValueIntent) async throws -> INObjectCollection<NSString> {
+        // TODO:
+        INObjectCollection(items: ["Home", "Lehmgrubenweg"])
+    }
+
     private let logger = Logger(subsystem: "org.openhab.app", category: "SetDimmerRollerValueIntent")
     private let itemCache: any ItemCacheProtocol
 
@@ -23,6 +33,7 @@ class SetDimmerRollerValueIntentHandler: NSObject, OpenHABSetDimmerRollerValueIn
     }
 
     func provideItemOptionsCollection(for intent: OpenHABSetDimmerRollerValueIntent, searchTerm: String?) async throws -> INObjectCollection<NSString> {
+        // TODO:
         let items = await itemCache.getItemNames(
             searchTerm: searchTerm,
             types: [.dimmer, .rollershutter]

--- a/openHABIntents/SetDimmerRollerValueIntentHandler.swift
+++ b/openHABIntents/SetDimmerRollerValueIntentHandler.swift
@@ -17,12 +17,12 @@ import os.log
 class SetDimmerRollerValueIntentHandler: NSObject, OpenHABSetDimmerRollerValueIntentHandling {
     private let logger = Logger(subsystem: "org.openhab.app", category: "SetDimmerRollerValueIntent")
 
-    func resolveHome(for intent: OpenHABSetDimmerRollerValueIntent) async -> INStringResolutionResult {
+    func resolveHome(for intent: OpenHABSetDimmerRollerValueIntent) async -> OpenHABHomeResolutionResult {
         logger.info("Resolving home for intent: \(intent)")
         return await OpenHABIntentHelper.resolveHome(home: intent.home, item: intent.item)
     }
 
-    func provideHomeOptionsCollection(for intent: OpenHABSetDimmerRollerValueIntent) async throws -> INObjectCollection<NSString> {
+    func provideHomeOptionsCollection(for intent: OpenHABSetDimmerRollerValueIntent) async throws -> INObjectCollection<OpenHABHome> {
         OpenHABIntentHelper.getHomeOptions()
     }
 
@@ -41,12 +41,13 @@ class SetDimmerRollerValueIntentHandler: NSObject, OpenHABSetDimmerRollerValueIn
     func handle(intent: OpenHABSetDimmerRollerValueIntent) async -> OpenHABSetDimmerRollerValueIntentResponse {
         logger.info("SetDimmerRollerValueIntent for \(intent.item ?? "")")
 
-        guard let itemName = intent.item, let homeName = intent.home else {
-            return .failureInvalidItem(NSLocalizedString("empty", comment: "empty item / home name"))
+        guard let itemName = intent.item, let home = intent.home else {
+            return .failureInvalidItem(
+                NSLocalizedString("empty", comment: "empty item / home name")
+            )
         }
 
-        let homeId = Preferences.firstStoredHome { $0.homeName == homeName }.map(\.id)
-        guard let homeId else {
+        guard let homeId = home.uuid, Preferences.storedHomes[homeId] != nil else {
             return .failureInvalidItem(NSLocalizedString("unknownHome", comment: "unknown home"))
         }
 

--- a/openHABIntents/SetDimmerRollerValueIntentHandler.swift
+++ b/openHABIntents/SetDimmerRollerValueIntentHandler.swift
@@ -21,8 +21,7 @@ class SetDimmerRollerValueIntentHandler: NSObject, OpenHABSetDimmerRollerValueIn
     }
 
     func provideHomeOptionsCollection(for intent: OpenHABSetDimmerRollerValueIntent) async throws -> INObjectCollection<NSString> {
-        // TODO:
-        INObjectCollection(items: ["Home", "Lehmgrubenweg"])
+        await INObjectCollection(items: Preferences.storedHomes.map(\.value.homeName).map { $0 as NSString })
     }
 
     private let logger = Logger(subsystem: "org.openhab.app", category: "SetDimmerRollerValueIntent")

--- a/openHABIntents/SetNumberValueIntentHandler.swift
+++ b/openHABIntents/SetNumberValueIntentHandler.swift
@@ -21,8 +21,7 @@ class SetNumberValueIntentHandler: NSObject, OpenHABSetNumberValueIntentHandling
     }
 
     func provideHomeOptionsCollection(for intent: OpenHABSetNumberValueIntent) async throws -> INObjectCollection<NSString> {
-        // TODO:
-        INObjectCollection(items: ["Home", "Lehmgrubenweg"])
+        await INObjectCollection(items: Preferences.storedHomes.map(\.value.homeName).map { $0 as NSString })
     }
 
     private let logger = Logger(subsystem: "org.openhab.app", category: "SetNumberValueIntent")

--- a/openHABIntents/SetNumberValueIntentHandler.swift
+++ b/openHABIntents/SetNumberValueIntentHandler.swift
@@ -15,6 +15,16 @@ import OpenHABCore
 import os.log
 
 class SetNumberValueIntentHandler: NSObject, OpenHABSetNumberValueIntentHandling {
+    func resolveHome(for intent: OpenHABSetNumberValueIntent) async -> INStringResolutionResult {
+        // TODO:
+        INStringResolutionResult.success(with: intent.home ?? "Home")
+    }
+
+    func provideHomeOptionsCollection(for intent: OpenHABSetNumberValueIntent) async throws -> INObjectCollection<NSString> {
+        // TODO:
+        INObjectCollection(items: ["Home", "Lehmgrubenweg"])
+    }
+
     private let logger = Logger(subsystem: "org.openhab.app", category: "SetNumberValueIntent")
     private let itemCache: any ItemCacheProtocol
 

--- a/openHABIntents/SetNumberValueIntentHandler.swift
+++ b/openHABIntents/SetNumberValueIntentHandler.swift
@@ -17,12 +17,12 @@ import os.log
 class SetNumberValueIntentHandler: NSObject, OpenHABSetNumberValueIntentHandling {
     private let logger = Logger(subsystem: "org.openhab.app", category: "SetNumberValueIntent")
 
-    func resolveHome(for intent: OpenHABSetNumberValueIntent) async -> INStringResolutionResult {
+    func resolveHome(for intent: OpenHABSetNumberValueIntent) async -> OpenHABHomeResolutionResult {
         logger.info("Resolving home for intent: \(intent)")
         return await OpenHABIntentHelper.resolveHome(home: intent.home, item: intent.item)
     }
 
-    func provideHomeOptionsCollection(for intent: OpenHABSetNumberValueIntent) async throws -> INObjectCollection<NSString> {
+    func provideHomeOptionsCollection(for intent: OpenHABSetNumberValueIntent) async throws -> INObjectCollection<OpenHABHome> {
         OpenHABIntentHelper.getHomeOptions()
     }
 
@@ -41,12 +41,13 @@ class SetNumberValueIntentHandler: NSObject, OpenHABSetNumberValueIntentHandling
     func handle(intent: OpenHABSetNumberValueIntent) async -> OpenHABSetNumberValueIntentResponse {
         logger.info("SetNumberValueIntent for \(intent.item ?? "")")
 
-        guard let itemName = intent.item, let homeName = intent.home else {
-            return .failureInvalidItem(NSLocalizedString("empty", comment: "empty item / home name"))
+        guard let itemName = intent.item, let home = intent.home else {
+            return .failureInvalidItem(
+                NSLocalizedString("empty", comment: "empty item / home name")
+            )
         }
 
-        let homeId = Preferences.firstStoredHome { $0.homeName == homeName }.map(\.id)
-        guard let homeId else {
+        guard let homeId = home.uuid, Preferences.storedHomes[homeId] != nil else {
             return .failureInvalidItem(NSLocalizedString("unknownHome", comment: "unknown home"))
         }
 

--- a/openHABIntents/SetNumberValueIntentHandler.swift
+++ b/openHABIntents/SetNumberValueIntentHandler.swift
@@ -15,34 +15,23 @@ import OpenHABCore
 import os.log
 
 class SetNumberValueIntentHandler: NSObject, OpenHABSetNumberValueIntentHandling {
+    private let logger = Logger(subsystem: "org.openhab.app", category: "SetNumberValueIntent")
+
     func resolveHome(for intent: OpenHABSetNumberValueIntent) async -> INStringResolutionResult {
-        // TODO:
-        INStringResolutionResult.success(with: intent.home ?? "Home")
+        logger.info("Resolving home for intent: \(intent)")
+        return await OpenHABIntentHelper.resolveHome(home: intent.home, item: intent.item)
     }
 
     func provideHomeOptionsCollection(for intent: OpenHABSetNumberValueIntent) async throws -> INObjectCollection<NSString> {
-        await INObjectCollection(items: Preferences.storedHomes.map(\.value.homeName).map { $0 as NSString })
-    }
-
-    private let logger = Logger(subsystem: "org.openhab.app", category: "SetNumberValueIntent")
-    private let itemCache: OpenHABItemCache
-
-    init(itemCache: OpenHABItemCache = OpenHABItemCache.instance) {
-        self.itemCache = itemCache
+        OpenHABIntentHelper.getHomeOptions()
     }
 
     func provideItemOptionsCollection(for intent: OpenHABSetNumberValueIntent, searchTerm: String?) async throws -> INObjectCollection<NSString> {
-        let items = await itemCache
-            .getItemNames(searchTerm: searchTerm, types: [.number])
-            .map(NSString.init)
-        return INObjectCollection(items: items)
+        await OpenHABIntentHelper.getItemOptions(home: intent.home, searchTerm: searchTerm, itemTypes: [.number])
     }
 
     func provideItemOptionsCollection(for intent: OpenHABSetNumberValueIntent) async throws -> INObjectCollection<NSString> {
-        let items = await itemCache
-            .getItemNames(searchTerm: nil, types: [.number])
-            .map(NSString.init)
-        return INObjectCollection(items: items)
+        await OpenHABIntentHelper.getItemOptions(home: intent.home, itemTypes: [.number])
     }
 
     func confirm(intent: OpenHABSetNumberValueIntent) async -> OpenHABSetNumberValueIntentResponse {
@@ -52,23 +41,26 @@ class SetNumberValueIntentHandler: NSObject, OpenHABSetNumberValueIntentHandling
     func handle(intent: OpenHABSetNumberValueIntent) async -> OpenHABSetNumberValueIntentResponse {
         logger.info("SetNumberValueIntent for \(intent.item ?? "")")
 
-        await OpenHABItemCache.instance.waitUntilReady()
+        guard let itemName = intent.item, let homeName = intent.home else {
+            return .failureInvalidItem(NSLocalizedString("empty", comment: "empty item / home name"))
+        }
 
-        guard let itemName = intent.item else {
-            return .failureInvalidItem(
-                NSLocalizedString("empty", comment: "empty item name")
-            )
+        let homeId = Preferences.firstStoredHome { $0.homeName == homeName }.map(\.id)
+        guard let homeId else {
+            return .failureInvalidItem(NSLocalizedString("unknownHome", comment: "unknown home"))
         }
 
         guard let value = intent.value else {
             return .failureEmptyValue(item: itemName)
         }
 
-        guard let item = await itemCache.getItem(name: itemName) else {
+        guard let items = await OpenHABItemCache.instance.getCachedItem(name: itemName, home: homeId), !items.isEmpty else {
             return .failureInvalidItem(itemName)
         }
 
-        await itemCache.sendCommand(item, commandToSend: value.stringValue)
+        let item = items[0]
+
+        await OpenHABItemCache.instance.sendCommand(to: item, home: homeId, command: value.stringValue)
 
         return .success(value: value, item: itemName)
     }

--- a/openHABIntents/SetNumberValueIntentHandler.swift
+++ b/openHABIntents/SetNumberValueIntentHandler.swift
@@ -25,9 +25,9 @@ class SetNumberValueIntentHandler: NSObject, OpenHABSetNumberValueIntentHandling
     }
 
     private let logger = Logger(subsystem: "org.openhab.app", category: "SetNumberValueIntent")
-    private let itemCache: any ItemCacheProtocol
+    private let itemCache: OpenHABItemCache
 
-    init(itemCache: any ItemCacheProtocol = OpenHABItemCache.instance) {
+    init(itemCache: OpenHABItemCache = OpenHABItemCache.instance) {
         self.itemCache = itemCache
     }
 

--- a/openHABIntents/SetStringValueIntentHandler.swift
+++ b/openHABIntents/SetStringValueIntentHandler.swift
@@ -25,9 +25,9 @@ class SetStringValueIntentHandler: NSObject, OpenHABSetStringValueIntentHandling
     }
 
     private let logger = Logger(subsystem: "org.openhab.app", category: "SetStringValueIntent")
-    private let itemCache: any ItemCacheProtocol
+    private let itemCache: OpenHABItemCache
 
-    init(itemCache: any ItemCacheProtocol = OpenHABItemCache.instance) {
+    init(itemCache: OpenHABItemCache = OpenHABItemCache.instance) {
         self.itemCache = itemCache
     }
 

--- a/openHABIntents/SetStringValueIntentHandler.swift
+++ b/openHABIntents/SetStringValueIntentHandler.swift
@@ -15,34 +15,23 @@ import OpenHABCore
 import os.log
 
 class SetStringValueIntentHandler: NSObject, OpenHABSetStringValueIntentHandling {
+    private let logger = Logger(subsystem: "org.openhab.app", category: "SetStringValueIntent")
+
     func resolveHome(for intent: OpenHABSetStringValueIntent) async -> INStringResolutionResult {
-        // TODO:
-        INStringResolutionResult.success(with: intent.home ?? "Home")
+        logger.info("Resolving home for intent: \(intent)")
+        return await OpenHABIntentHelper.resolveHome(home: intent.home, item: intent.item)
     }
 
     func provideHomeOptionsCollection(for intent: OpenHABSetStringValueIntent) async throws -> INObjectCollection<NSString> {
-        await INObjectCollection(items: Preferences.storedHomes.map(\.value.homeName).map { $0 as NSString })
-    }
-
-    private let logger = Logger(subsystem: "org.openhab.app", category: "SetStringValueIntent")
-    private let itemCache: OpenHABItemCache
-
-    init(itemCache: OpenHABItemCache = OpenHABItemCache.instance) {
-        self.itemCache = itemCache
+        OpenHABIntentHelper.getHomeOptions()
     }
 
     func provideItemOptionsCollection(for intent: OpenHABSetStringValueIntent, searchTerm: String?) async throws -> INObjectCollection<NSString> {
-        let items = await itemCache
-            .getItemNames(searchTerm: searchTerm, types: [.stringItem])
-            .map(NSString.init)
-        return INObjectCollection(items: items)
+        await OpenHABIntentHelper.getItemOptions(home: intent.home, searchTerm: searchTerm, itemTypes: [.stringItem])
     }
 
     func provideItemOptionsCollection(for intent: OpenHABSetStringValueIntent) async throws -> INObjectCollection<NSString> {
-        let items = await itemCache
-            .getItemNames(searchTerm: nil, types: [.stringItem])
-            .map(NSString.init)
-        return INObjectCollection(items: items)
+        await OpenHABIntentHelper.getItemOptions(home: intent.home, itemTypes: [.stringItem])
     }
 
     func confirm(intent: OpenHABSetStringValueIntent) async -> OpenHABSetStringValueIntentResponse {
@@ -52,23 +41,26 @@ class SetStringValueIntentHandler: NSObject, OpenHABSetStringValueIntentHandling
     func handle(intent: OpenHABSetStringValueIntent) async -> OpenHABSetStringValueIntentResponse {
         logger.info("SetStringValueIntent for \(intent.item ?? "")")
 
-        await OpenHABItemCache.instance.waitUntilReady()
+        guard let itemName = intent.item, let homeName = intent.home else {
+            return .failureInvalidItem(NSLocalizedString("empty", comment: "empty item / home name"))
+        }
 
-        guard let itemName = intent.item else {
-            return .failureInvalidItem(
-                NSLocalizedString("empty", comment: "empty item name")
-            )
+        let homeId = Preferences.firstStoredHome { $0.homeName == homeName }.map(\.id)
+        guard let homeId else {
+            return .failureInvalidItem(NSLocalizedString("unknownHome", comment: "unknown home"))
         }
 
         guard let value = intent.value else {
             return .failureEmptyValue(item: itemName)
         }
 
-        guard let item = await itemCache.getItem(name: itemName) else {
+        guard let items = await OpenHABItemCache.instance.getCachedItem(name: itemName, home: homeId), !items.isEmpty else {
             return .failureInvalidItem(itemName)
         }
 
-        await itemCache.sendCommand(item, commandToSend: value)
+        let item = items[0]
+
+        await OpenHABItemCache.instance.sendCommand(to: item, home: homeId, command: value)
 
         return .success(value: value, item: itemName)
     }

--- a/openHABIntents/SetStringValueIntentHandler.swift
+++ b/openHABIntents/SetStringValueIntentHandler.swift
@@ -15,6 +15,16 @@ import OpenHABCore
 import os.log
 
 class SetStringValueIntentHandler: NSObject, OpenHABSetStringValueIntentHandling {
+    func resolveHome(for intent: OpenHABSetStringValueIntent) async -> INStringResolutionResult {
+        // TODO:
+        INStringResolutionResult.success(with: intent.home ?? "Home")
+    }
+
+    func provideHomeOptionsCollection(for intent: OpenHABSetStringValueIntent) async throws -> INObjectCollection<NSString> {
+        // TODO:
+        INObjectCollection(items: ["Home", "Lehmgrubenweg"])
+    }
+
     private let logger = Logger(subsystem: "org.openhab.app", category: "SetStringValueIntent")
     private let itemCache: any ItemCacheProtocol
 

--- a/openHABIntents/SetStringValueIntentHandler.swift
+++ b/openHABIntents/SetStringValueIntentHandler.swift
@@ -21,8 +21,7 @@ class SetStringValueIntentHandler: NSObject, OpenHABSetStringValueIntentHandling
     }
 
     func provideHomeOptionsCollection(for intent: OpenHABSetStringValueIntent) async throws -> INObjectCollection<NSString> {
-        // TODO:
-        INObjectCollection(items: ["Home", "Lehmgrubenweg"])
+        await INObjectCollection(items: Preferences.storedHomes.map(\.value.homeName).map { $0 as NSString })
     }
 
     private let logger = Logger(subsystem: "org.openhab.app", category: "SetStringValueIntent")

--- a/openHABIntents/SetStringValueIntentHandler.swift
+++ b/openHABIntents/SetStringValueIntentHandler.swift
@@ -17,12 +17,12 @@ import os.log
 class SetStringValueIntentHandler: NSObject, OpenHABSetStringValueIntentHandling {
     private let logger = Logger(subsystem: "org.openhab.app", category: "SetStringValueIntent")
 
-    func resolveHome(for intent: OpenHABSetStringValueIntent) async -> INStringResolutionResult {
+    func resolveHome(for intent: OpenHABSetStringValueIntent) async -> OpenHABHomeResolutionResult {
         logger.info("Resolving home for intent: \(intent)")
         return await OpenHABIntentHelper.resolveHome(home: intent.home, item: intent.item)
     }
 
-    func provideHomeOptionsCollection(for intent: OpenHABSetStringValueIntent) async throws -> INObjectCollection<NSString> {
+    func provideHomeOptionsCollection(for intent: OpenHABSetStringValueIntent) async throws -> INObjectCollection<OpenHABHome> {
         OpenHABIntentHelper.getHomeOptions()
     }
 
@@ -41,12 +41,13 @@ class SetStringValueIntentHandler: NSObject, OpenHABSetStringValueIntentHandling
     func handle(intent: OpenHABSetStringValueIntent) async -> OpenHABSetStringValueIntentResponse {
         logger.info("SetStringValueIntent for \(intent.item ?? "")")
 
-        guard let itemName = intent.item, let homeName = intent.home else {
-            return .failureInvalidItem(NSLocalizedString("empty", comment: "empty item / home name"))
+        guard let itemName = intent.item, let home = intent.home else {
+            return .failureInvalidItem(
+                NSLocalizedString("empty", comment: "empty item / home name")
+            )
         }
 
-        let homeId = Preferences.firstStoredHome { $0.homeName == homeName }.map(\.id)
-        guard let homeId else {
+        guard let homeId = home.uuid, Preferences.storedHomes[homeId] != nil else {
             return .failureInvalidItem(NSLocalizedString("unknownHome", comment: "unknown home"))
         }
 

--- a/openHABIntents/SetSwitchStateIntentHandler.swift
+++ b/openHABIntents/SetSwitchStateIntentHandler.swift
@@ -35,9 +35,9 @@ final class SetSwitchStateIntentHandler: NSObject, OpenHABSetSwitchStateIntentHa
 
     private let logger = Logger(subsystem: "org.openhab.app", category: "SetSwitchStateIntent")
 
-    private let itemCache: any ItemCacheProtocol
+    private let itemCache: OpenHABItemCache
 
-    init(itemCache: any ItemCacheProtocol = OpenHABItemCache.instance) {
+    init(itemCache: OpenHABItemCache = OpenHABItemCache.instance) {
         self.itemCache = itemCache
     }
 

--- a/openHABIntents/SetSwitchStateIntentHandler.swift
+++ b/openHABIntents/SetSwitchStateIntentHandler.swift
@@ -26,12 +26,12 @@ final class SetSwitchStateIntentHandler: NSObject, OpenHABSetSwitchStateIntentHa
 
     private let logger = Logger(subsystem: "org.openhab.app", category: "SetSwitchStateIntent")
 
-    func resolveHome(for intent: OpenHABSetSwitchStateIntent) async -> INStringResolutionResult {
+    func resolveHome(for intent: OpenHABSetSwitchStateIntent) async -> OpenHABHomeResolutionResult {
         logger.info("Resolving home for intent: \(intent)")
         return await OpenHABIntentHelper.resolveHome(home: intent.home, item: intent.item)
     }
 
-    func provideHomeOptionsCollection(for intent: OpenHABSetSwitchStateIntent) async throws -> INObjectCollection<NSString> {
+    func provideHomeOptionsCollection(for intent: OpenHABSetSwitchStateIntent) async throws -> INObjectCollection<OpenHABHome> {
         OpenHABIntentHelper.getHomeOptions()
     }
 
@@ -57,12 +57,13 @@ final class SetSwitchStateIntentHandler: NSObject, OpenHABSetSwitchStateIntentHa
     func handle(intent: OpenHABSetSwitchStateIntent) async -> OpenHABSetSwitchStateIntentResponse {
         logger.info("SetSwitchStateIntent for item: \(intent.item ?? "<none>", privacy: .public)")
 
-        guard let itemName = intent.item, let homeName = intent.home else {
-            return .failureInvalidItem(NSLocalizedString("empty", comment: "empty item / home name"))
+        guard let itemName = intent.item, let home = intent.home else {
+            return .failureInvalidItem(
+                NSLocalizedString("empty", comment: "empty item / home name")
+            )
         }
 
-        let homeId = Preferences.firstStoredHome { $0.homeName == homeName }.map(\.id)
-        guard let homeId else {
+        guard let homeId = home.uuid, Preferences.storedHomes[homeId] != nil else {
             return .failureInvalidItem(NSLocalizedString("unknownHome", comment: "unknown home"))
         }
 

--- a/openHABIntents/SetSwitchStateIntentHandler.swift
+++ b/openHABIntents/SetSwitchStateIntentHandler.swift
@@ -15,6 +15,16 @@ import OpenHABCore
 import os
 
 final class SetSwitchStateIntentHandler: NSObject, OpenHABSetSwitchStateIntentHandling {
+    func resolveHome(for intent: OpenHABSetSwitchStateIntent) async -> INStringResolutionResult {
+        // TODO:
+        INStringResolutionResult.success(with: intent.home ?? "Home")
+    }
+
+    func provideHomeOptionsCollection(for intent: OpenHABSetSwitchStateIntent) async throws -> INObjectCollection<NSString> {
+        // TODO:
+        INObjectCollection(items: ["Home", "Lehmgrubenweg"])
+    }
+
     private static let onLabel = NSLocalizedString("on", comment: "").capitalized
     private static let offLabel = NSLocalizedString("off", comment: "").capitalized
 

--- a/openHABIntents/SetSwitchStateIntentHandler.swift
+++ b/openHABIntents/SetSwitchStateIntentHandler.swift
@@ -21,8 +21,7 @@ final class SetSwitchStateIntentHandler: NSObject, OpenHABSetSwitchStateIntentHa
     }
 
     func provideHomeOptionsCollection(for intent: OpenHABSetSwitchStateIntent) async throws -> INObjectCollection<NSString> {
-        // TODO:
-        INObjectCollection(items: ["Home", "Lehmgrubenweg"])
+        await INObjectCollection(items: Preferences.storedHomes.map(\.value.homeName).map { $0 as NSString })
     }
 
     private static let onLabel = NSLocalizedString("on", comment: "").capitalized

--- a/openHABIntents/SetSwitchStateIntentHandler.swift
+++ b/openHABIntents/SetSwitchStateIntentHandler.swift
@@ -15,15 +15,6 @@ import OpenHABCore
 import os
 
 final class SetSwitchStateIntentHandler: NSObject, OpenHABSetSwitchStateIntentHandling {
-    func resolveHome(for intent: OpenHABSetSwitchStateIntent) async -> INStringResolutionResult {
-        // TODO:
-        INStringResolutionResult.success(with: intent.home ?? "Home")
-    }
-
-    func provideHomeOptionsCollection(for intent: OpenHABSetSwitchStateIntent) async throws -> INObjectCollection<NSString> {
-        await INObjectCollection(items: Preferences.storedHomes.map(\.value.homeName).map { $0 as NSString })
-    }
-
     private static let onLabel = NSLocalizedString("on", comment: "").capitalized
     private static let offLabel = NSLocalizedString("off", comment: "").capitalized
 
@@ -35,10 +26,13 @@ final class SetSwitchStateIntentHandler: NSObject, OpenHABSetSwitchStateIntentHa
 
     private let logger = Logger(subsystem: "org.openhab.app", category: "SetSwitchStateIntent")
 
-    private let itemCache: OpenHABItemCache
+    func resolveHome(for intent: OpenHABSetSwitchStateIntent) async -> INStringResolutionResult {
+        logger.info("Resolving home for intent: \(intent)")
+        return await OpenHABIntentHelper.resolveHome(home: intent.home, item: intent.item)
+    }
 
-    init(itemCache: OpenHABItemCache = OpenHABItemCache.instance) {
-        self.itemCache = itemCache
+    func provideHomeOptionsCollection(for intent: OpenHABSetSwitchStateIntent) async throws -> INObjectCollection<NSString> {
+        OpenHABIntentHelper.getHomeOptions()
     }
 
     func provideActionOptionsCollection(for intent: OpenHABSetSwitchStateIntent) async throws -> INObjectCollection<NSString> {
@@ -48,21 +42,12 @@ final class SetSwitchStateIntentHandler: NSObject, OpenHABSetSwitchStateIntentHa
 
     func provideItemOptionsCollection(for intent: OpenHABSetSwitchStateIntent, searchTerm: String?) async throws -> INObjectCollection<NSString> {
         logger.info("SetSwitchStateIntentHandler provideItemOptionsCollection with searchTerm: \(searchTerm ?? "<none>", privacy: .public)")
-
-        let itemNames = await itemCache
-            .getItemNames(
-                searchTerm: searchTerm,
-                types: [.switchItem]
-            )
-            .map(NSString.init)
-
-        return INObjectCollection(items: itemNames)
+        return await OpenHABIntentHelper.getItemOptions(home: intent.home, searchTerm: searchTerm, itemTypes: [.switchItem])
     }
 
     func provideItemOptionsCollection(for intent: OpenHABSetSwitchStateIntent) async throws -> INObjectCollection<NSString> {
         logger.info("SetSwitchStateIntentHandler provideItemOptionsCollection")
-
-        return try await provideItemOptionsCollection(for: intent, searchTerm: nil)
+        return await OpenHABIntentHelper.getItemOptions(home: intent.home, itemTypes: [.switchItem])
     }
 
     func confirm(intent: OpenHABSetSwitchStateIntent) async -> OpenHABSetSwitchStateIntentResponse {
@@ -70,10 +55,16 @@ final class SetSwitchStateIntentHandler: NSObject, OpenHABSetSwitchStateIntentHa
     }
 
     func handle(intent: OpenHABSetSwitchStateIntent) async -> OpenHABSetSwitchStateIntentResponse {
-        let itemName = intent.item ?? ""
         logger.info("SetSwitchStateIntent for item: \(intent.item ?? "<none>", privacy: .public)")
 
-        await OpenHABItemCache.instance.waitUntilReady()
+        guard let itemName = intent.item, let homeName = intent.home else {
+            return .failureInvalidItem(NSLocalizedString("empty", comment: "empty item / home name"))
+        }
+
+        let homeId = Preferences.firstStoredHome { $0.homeName == homeName }.map(\.id)
+        guard let homeId else {
+            return .failureInvalidItem(NSLocalizedString("unknownHome", comment: "unknown home"))
+        }
 
         guard !itemName.isEmpty else {
             return .failureInvalidItem(NSLocalizedString("empty", comment: "empty item name"))
@@ -87,11 +78,13 @@ final class SetSwitchStateIntentHandler: NSObject, OpenHABSetSwitchStateIntentHa
             return .failureInvalidAction(action, item: itemName)
         }
 
-        guard let item = await itemCache.getItem(name: itemName) else {
+        guard let items = await OpenHABItemCache.instance.getCachedItem(name: itemName, home: homeId), !items.isEmpty else {
             return .failureInvalidItem(itemName)
         }
 
-        await itemCache.sendCommand(item, commandToSend: command)
+        let item = items[0]
+
+        await OpenHABItemCache.instance.sendCommand(to: item, home: homeId, command: command)
         return .success(action: action, item: itemName)
     }
 }


### PR DESCRIPTION
I tried making the change as unintrusive as possible, and all existing automations should stay as they are.

Even if no home name provided, as long as the item name is unique, all shortcuts will work.

There is an edge case where two homes have the same item name, and no home name is provided. It should work in theory, the code is supposed to ask for disambiguation then, but I have not tested it yet.