### PR TITLE
Resolve off‑main SVG rendering via UIGraphicsImageRenderer.

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Util/OpenHABImageProcessor.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/OpenHABImageProcessor.swift
@@ -26,6 +26,35 @@ public struct OpenHABImageProcessor: ImageProcessor {
         identifier = "org.openhab.svgprocessor"
     }
 
+    /// Execute `body` on the main thread synchronously, but avoid deadlock when already on main.
+    @inline(__always)
+    private func mainSync<T: Sendable>(_ body: @Sendable () -> T) -> T {
+        if Thread.isMainThread {
+            // We *are* on main; it's now safe to assert MainActor context if you want.
+            MainActor.assumeIsolated { body() }
+        } else {
+            DispatchQueue.main.sync {
+                body()
+            }
+        }
+    }
+
+    /// Decode SVG on the main thread (UIGraphics-based), with sane defaults.
+    private func decodeSVGOnMain(_ data: Data) -> UIImage? {
+        mainSync {
+            SDImageSVGCoder.shared.decodedImage(
+                with: data,
+                options: nil
+            )
+        }
+    }
+
+    /// Convenience fallback symbol (orange triangle), always original rendering.
+    private func warningSymbol() -> UIImage {
+        let img = UIImage(systemSymbol: .exclamationmarkTriangle)
+        return img.withTintColor(.orange, renderingMode: .alwaysOriginal)
+    }
+
     // Convert input data/image to target image and return it.
     public func process(item: ImageProcessItem, options: KingfisherParsedOptionsInfo) -> KFCrossPlatformImage? {
         switch item {
@@ -35,20 +64,28 @@ public struct OpenHABImageProcessor: ImageProcessor {
         case let .data(data):
             guard !data.isEmpty else { return nil }
 
-            switch data[0] {
-            case 0x3C: // Likely SVG, since it starts with '<'
-                if let image = SDImageSVGCoder.shared.decodedImage(with: data, options: nil) {
+            if isSVG(data: data) {
+                if let image = decodeSVGOnMain(data) {
                     let size = image.size
                     if size.width > 1000 || size.height > 1000 {
-                        return UIImage(systemSymbol: .exclamationmarkTriangle).withTintColor(.orange, renderingMode: .alwaysOriginal)
+                        logger.warning("SVG decoded to very large bitmap: \(size.width, privacy: .public)x\(size.height, privacy: .public)")
+                        return warningSymbol()
                     }
                     return image
                 } else {
-                    return UIImage(systemSymbol: .exclamationmarkTriangle).withTintColor(.orange, renderingMode: .alwaysOriginal)
+                    return warningSymbol()
                 }
-            default:
+            } else {
                 return Kingfisher.DefaultImageProcessor().process(item: item, options: KingfisherParsedOptionsInfo(KingfisherManager.shared.defaultOptions))
             }
         }
+    }
+
+    private func isSVG(data: Data?) -> Bool {
+        guard let data else { return false }
+        if let start = String(data: data.prefix(200), encoding: .utf8) {
+            return start.contains("<svg") || start.hasPrefix("<?xml")
+        }
+        return false
     }
 }

--- a/openHAB/AppDelegate.swift
+++ b/openHAB/AppDelegate.swift
@@ -100,8 +100,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         activateWatchConnectivity()
 
-        let SVGCoder = SDImageSVGCoder.shared
-        SDImageCodersManager.shared.addCoder(SVGCoder)
+        configureImageCoders()
 
         /// load and start the screensaver
         if let keyWindow = UIApplication.shared.firstKeyWindow {
@@ -125,6 +124,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         return true
+    }
+
+    @MainActor
+    func configureImageCoders() {
+        let svgCoder = SDImageSVGCoder.shared
+        SDImageCodersManager.shared.addCoder(svgCoder)
+        logger.info("SDImageSVGCoder registered")
     }
 
     private func setupFirebase() {


### PR DESCRIPTION
Detect SVGs and run the decoding/drawing step on the MainActor. Keep everything else background

Fix for 2 crashes related to SVG decoding: Crash Feedback (Aug 20, 2025 at 9:18 PM and 9:55PM).