### PR TITLE
Fix #947

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/GeneratedSources/openapi/Types.swift
+++ b/OpenHABCore/Sources/OpenHABCore/GeneratedSources/openapi/Types.swift
@@ -2472,6 +2472,8 @@ public enum Components {
             public var metadata: Components.Schemas.EnrichedItemDTO.metadataPayload?
             /// - Remark: Generated from `#/components/schemas/EnrichedItemDTO/editable`.
             public var editable: Swift.Bool?
+            /// - Remark: Generated from `#/components/schemas/EnrichedItemDTO/groupType`.
+            public var groupType: Swift.String?
             /// Creates a new `EnrichedItemDTO`.
             ///
             /// - Parameters:
@@ -2489,6 +2491,7 @@ public enum Components {
             ///   - commandDescription:
             ///   - metadata:
             ///   - editable:
+            ///   - groupType:
             public init(
                 _type: Swift.String? = nil,
                 name: Swift.String? = nil,
@@ -2503,7 +2506,8 @@ public enum Components {
                 unitSymbol: Swift.String? = nil,
                 commandDescription: Components.Schemas.CommandDescription? = nil,
                 metadata: Components.Schemas.EnrichedItemDTO.metadataPayload? = nil,
-                editable: Swift.Bool? = nil
+                editable: Swift.Bool? = nil,
+                groupType: Swift.String? = nil
             ) {
                 self._type = _type
                 self.name = name
@@ -2519,6 +2523,7 @@ public enum Components {
                 self.commandDescription = commandDescription
                 self.metadata = metadata
                 self.editable = editable
+                self.groupType = groupType
             }
             public enum CodingKeys: String, CodingKey {
                 case _type = "type"
@@ -2535,6 +2540,7 @@ public enum Components {
                 case commandDescription
                 case metadata
                 case editable
+                case groupType
             }
         }
         /// - Remark: Generated from `#/components/schemas/GroupFunctionDTO`.

--- a/OpenHABCore/Sources/OpenHABCore/Model/OpenHABItem.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/OpenHABItem.swift
@@ -161,7 +161,7 @@ extension OpenHABItem {
                 state: item.state.orEmpty,
                 link: item.link.orEmpty,
                 label: item.label.orEmpty,
-                groupType: nil,
+                groupType: item.groupType,
                 stateDescription: OpenHABStateDescription(item.stateDescription),
                 commandDescription: OpenHABCommandDescription(item.commandDescription),
                 members: [],

--- a/OpenHABCore/Sources/OpenHABCore/openapi/openapi.json
+++ b/OpenHABCore/Sources/OpenHABCore/openapi/openapi.json
@@ -8393,6 +8393,9 @@
           },
           "editable": {
             "type": "boolean"
+          },
+          "groupType": {
+              "type": "string"
           }
         }
       },


### PR DESCRIPTION
Added `groupType` field to the OpenAPI JSON schema for EnrichedItemDTO
Updated generated Swift types to include the new `groupType` property
Modified OpenHABItem extension to use the actual `groupType` value instead of hardcoded `nil`
