### PR TITLE
Async version of notificationcenter delegate

### DIFF
--- a/NotificationService/NotificationService.swift
+++ b/NotificationService/NotificationService.swift
@@ -96,9 +96,10 @@ actor NotificationServiceHandler {
                         intentIdentifiers: [],
                         options: .customDismissAction
                     )
+                let logger = logger
                 UNUserNotificationCenter.current().getNotificationCategories { existingCategories in
                     var updatedCategories = existingCategories
-                    self.logger.info("handleNotification adding category \(category)")
+                    logger.info("handleNotification adding category \(category)")
                     updatedCategories.insert(notificationCategory)
                     UNUserNotificationCenter.current().setNotificationCategories(updatedCategories)
                 }

--- a/openHAB.xcodeproj/project.pbxproj
+++ b/openHAB.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		1224F78F228A89FD00750965 /* WatchMessageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1224F78D228A89FC00750965 /* WatchMessageService.swift */; };
+		2F08AFC72E5FADCF00E70611 /* NotificationCenterDelegateImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F08AFC62E5FADC500E70611 /* NotificationCenterDelegateImpl.swift */; };
 		2F55E7BB2DEE447700EC8350 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F55E7BA2DEE447700EC8350 /* SettingsView.swift */; };
 		2F55E7BD2DEE44A800EC8350 /* ClientCertificatesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F55E7BC2DEE44A800EC8350 /* ClientCertificatesView.swift */; };
 		2F6412EE2CE494A80039FB28 /* DatePickerUITableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F6412ED2CE494A80039FB28 /* DatePickerUITableViewCell.swift */; };
@@ -283,6 +284,7 @@
 
 /* Begin PBXFileReference section */
 		1224F78D228A89FC00750965 /* WatchMessageService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WatchMessageService.swift; sourceTree = "<group>"; };
+		2F08AFC62E5FADC500E70611 /* NotificationCenterDelegateImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenterDelegateImpl.swift; sourceTree = "<group>"; };
 		2F55E7BA2DEE447700EC8350 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		2F55E7BC2DEE44A800EC8350 /* ClientCertificatesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientCertificatesView.swift; sourceTree = "<group>"; };
 		2F6412ED2CE494A80039FB28 /* DatePickerUITableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerUITableViewCell.swift; sourceTree = "<group>"; };
@@ -512,17 +514,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		DA2AEB752D92D32000897D80 /* Cells */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = Cells;
-			sourceTree = "<group>";
-		};
+		DA2AEB752D92D32000897D80 /* Cells */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Cells; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1079,6 +1071,7 @@
 				938BF9C324EFCB9F00E6B52F /* Main.storyboard */,
 				A3F4C3A41A49A5940019A09F /* MainLaunchScreen.xib */,
 				DFB2623A18830A3600D3244D /* AppDelegate.swift */,
+				2F08AFC62E5FADC500E70611 /* NotificationCenterDelegateImpl.swift */,
 				DFDEE3FE1883228C008B26AC /* Models */,
 				DF4B84051885AD4600F34902 /* Images */,
 				DF4B83FD18857FA100F34902 /* UI */,
@@ -1663,6 +1656,7 @@
 				DA48001A2D83742A009CF127 /* DebugSettingsView.swift in Sources */,
 				938BF9D324EFD0B700E6B52F /* UIViewController+Localization.swift in Sources */,
 				DAA42BA821DC97E000244B2A /* NotificationTableViewCell.swift in Sources */,
+				2F08AFC72E5FADCF00E70611 /* NotificationCenterDelegateImpl.swift in Sources */,
 				DAF0A28F2C56F1EE00A14A6A /* ColorPickerCell.swift in Sources */,
 				2FEFD8F62BE7C5BE00E387B9 /* TextInputUITableViewCell.swift in Sources */,
 				938EDCE122C4FEB800661CA1 /* ScaleAspectFitImageView.swift in Sources */,

--- a/openHAB/AppDelegate.swift
+++ b/openHAB/AppDelegate.swift
@@ -22,41 +22,17 @@ import UIKit
 @preconcurrency import UserNotifications
 import WatchConnectivity
 
-actor AudioPlayerActor {
-    private var player: AVAudioPlayer?
-
-    let logger = Logger(subsystem: "org.openhab", category: "AudioPlayerActor")
-
-    func playSound() {
-        guard let soundPath = Bundle.main.url(forResource: "ping", withExtension: "wav") else {
-            return
-        }
-
-        do {
-            let newPlayer = try AVAudioPlayer(contentsOf: soundPath)
-            newPlayer.numberOfLoops = 0
-            newPlayer.play()
-            player = newPlayer
-        } catch {
-            logger.info("Failed to play sound \(error.localizedDescription)")
-        }
-    }
-
-    func stopSound() {
-        player?.stop()
-    }
-}
-
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     static var appDelegate: AppDelegate!
 
     private let logger = Logger(subsystem: "org.openhab", category: "AppDelegate")
 
-    let audioPlayer = AudioPlayerActor()
     var window: UIWindow?
 
     private var crashlyticsSubscriber: AnyCancellable?
+
+    private let notificationDelegate = NotificationCenterDelegateImpl()
 
     // Delegate Requests from the Watch to the WatchMessageService
     var session: WCSession? {
@@ -85,6 +61,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         UserDefaults.standard.register(defaults: appDefaults)
 
         Preferences.migratePreferences()
+
+        UNUserNotificationCenter.current().delegate = notificationDelegate
 
         registerForPushNotifications()
         logger.info("uniq id: \(UIDevice.current.identifierForVendor?.uuidString ?? "")")
@@ -172,7 +150,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 }
             }
         }
-        UNUserNotificationCenter.current().delegate = self
     }
 
     func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool {
@@ -194,7 +171,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // remove the 'openhab' from the url
         let action = url.absoluteString.split(separator: ":").dropFirst().joined(separator: ":")
-        notifyNotificationListeners(action: action)
+        notificationDelegate.notifyNotificationListeners(action: action)
         return true
     }
 
@@ -236,108 +213,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         return .newData
-    }
-}
-
-extension AppDelegate: @preconcurrency UNUserNotificationCenterDelegate {
-    // this is called when a notification comes in while in the foreground
-    nonisolated func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification) async -> UNNotificationPresentationOptions {
-        let userInfo = notification.request.content.userInfo
-        logger.info("Notification received while app is in foreground: \(userInfo)")
-
-        NotificationCenter.default.post(
-            name: .openHABDidReceiveNotification,
-            object: nil,
-            userInfo: userInfo
-        )
-
-        let message = userInfo["message"] as? String ?? NSLocalizedString("message_not_decoded", comment: "")
-        let action = userInfo["actionIdentifier"] as? String ?? userInfo["on-click"] as? String
-        let cloudUserId = userInfo["userId"] as? String
-        await displayNotification(message: message, action: action, cloudUserId: cloudUserId)
-
-        return [] // Modify this if you want to show banners, alerts, etc.
-    }
-
-    // this is called when clicking a notification while in the background
-    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-        var userInfo = response.notification.request.content.userInfo
-        let actionIdentifier = response.actionIdentifier
-
-        logger.info("Notification clicked: action \(actionIdentifier)")
-
-        if actionIdentifier != UNNotificationDismissActionIdentifier {
-            if actionIdentifier != UNNotificationDefaultActionIdentifier {
-                userInfo["actionIdentifier"] = actionIdentifier
-            }
-            let action = userInfo["actionIdentifier"] as? String ?? userInfo["on-click"] as? String
-            let cloudUserId = userInfo["userId"] as? String
-
-            notifyNotificationListeners(action: action, cloudUserId: cloudUserId)
-        }
-
-        completionHandler()
-    }
-
-    private func displayNotification(message: String, action: String?, cloudUserId: String?) async {
-        logger.info("displayNotification \(message)")
-
-        Task {
-            await audioPlayer.playSound()
-        }
-
-        var config = SwiftMessages.Config()
-        config.duration = .seconds(seconds: 5)
-        config.presentationStyle = .bottom
-
-        class MessageTapGestureRecognizer: UITapGestureRecognizer {
-            private let handler: () -> Void
-
-            init(handler: @escaping () -> Void) {
-                self.handler = handler
-                super.init(target: nil, action: nil)
-                addTarget(self, action: #selector(handleTap))
-            }
-
-            @objc private func handleTap() {
-                handler()
-            }
-        }
-
-        await MainActor.run {
-            SwiftMessages.show(config: config) {
-                let view = MessageView.viewFromNib(layout: .cardView)
-                view.configureTheme(.info)
-                view.configureContent(title: NSLocalizedString("notification", comment: ""), body: message)
-                view.button?.setTitle(NSLocalizedString("dismiss", comment: ""), for: .normal)
-                view.buttonTapHandler = { _ in SwiftMessages.hide() }
-
-                // Use closure-based tap gesture insteae of #selector
-                let tapGesture = MessageTapGestureRecognizer {
-                    self.messageViewTapped(action: action, cloudUserId: cloudUserId)
-                }
-                view.addGestureRecognizer(tapGesture)
-
-                return view
-            }
-        }
-    }
-
-    // Action to be performed when the notification message view is tapped
-    func messageViewTapped(action: String?, cloudUserId: String? = nil) {
-        notifyNotificationListeners(action: action, cloudUserId: cloudUserId)
-        SwiftMessages.hideAll()
-    }
-
-    @MainActor
-    private func notifyNotificationListeners(action: String?, cloudUserId: String? = nil) {
-        // Wake up screen saver immediately on incoming notification interaction
-        NotificationCenter.default.post(name: .wakeScreenSaver, object: nil)
-
-        if let navigationController = window?.rootViewController as? UINavigationController,
-           let rootViewController = navigationController.viewControllers.first as? OpenHABRootViewController {
-            rootViewController.handleNotification(action: action, cloudUserId: cloudUserId)
-        }
     }
 }
 

--- a/openHAB/NotificationCenterDelegateImpl.swift
+++ b/openHAB/NotificationCenterDelegateImpl.swift
@@ -1,0 +1,160 @@
+// Copyright (c) 2010-2025 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+import AVFoundation
+import Combine
+import Firebase
+import FirebaseMessaging
+import Kingfisher
+import OpenHABCore
+import os.log
+import SDWebImageSVGCoder
+import SwiftMessages
+import UIKit
+@preconcurrency import UserNotifications
+import WatchConnectivity
+
+actor AudioPlayerActor {
+    private var player: AVAudioPlayer?
+
+    let logger = Logger(subsystem: "org.openhab", category: "AudioPlayerActor")
+
+    func playSound() {
+        guard let soundPath = Bundle.main.url(forResource: "ping", withExtension: "wav") else {
+            return
+        }
+
+        do {
+            let newPlayer = try AVAudioPlayer(contentsOf: soundPath)
+            newPlayer.numberOfLoops = 0
+            newPlayer.play()
+            player = newPlayer
+        } catch {
+            logger.info("Failed to play sound \(error.localizedDescription)")
+        }
+    }
+
+    func stopSound() {
+        player?.stop()
+    }
+}
+
+@MainActor
+final class NotificationCenterDelegateImpl: NSObject, UNUserNotificationCenterDelegate {
+    private let logger = Logger(subsystem: "org.openhab", category: "NotificationCenterDelegateImpl")
+
+    let audioPlayer = AudioPlayerActor()
+
+    // this is called when a notification comes in while in the foreground
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification) async -> UNNotificationPresentationOptions {
+        let userInfo = notification.request.content.userInfo
+        logger.info("Notification received while app is in foreground: \(userInfo)")
+
+        NotificationCenter.default.post(
+            name: .openHABDidReceiveNotification,
+            object: nil,
+            userInfo: userInfo
+        )
+
+        let message = userInfo["message"] as? String ?? NSLocalizedString("message_not_decoded", comment: "")
+        let action = userInfo["actionIdentifier"] as? String ?? userInfo["on-click"] as? String
+        let cloudUserId = userInfo["userId"] as? String
+        await displayNotification(message: message, action: action, cloudUserId: cloudUserId)
+
+        return [] // Modify this if you want to show banners, alerts, etc.
+    }
+
+    // this is called when clicking a notification while in the background
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) async {
+        var userInfo = response.notification.request.content.userInfo
+        let actionIdentifier = response.actionIdentifier
+
+        logger.info("Notification clicked: action \(actionIdentifier) userInfo \(userInfo)")
+
+        if actionIdentifier != UNNotificationDismissActionIdentifier {
+            if actionIdentifier != UNNotificationDefaultActionIdentifier {
+                userInfo["actionIdentifier"] = actionIdentifier
+            }
+            let action = userInfo["actionIdentifier"] as? String ?? userInfo["on-click"] as? String
+            let cloudUserId = userInfo["userId"] as? String
+
+            notifyNotificationListeners(action: action, cloudUserId: cloudUserId)
+        }
+    }
+
+    private func displayNotification(message: String, action: String?, cloudUserId: String?) async {
+        logger.info("displayNotification \(message)")
+
+        Task {
+            await audioPlayer.playSound()
+        }
+
+        var config = SwiftMessages.Config()
+        config.duration = .seconds(seconds: 5)
+        config.presentationStyle = .bottom
+
+        class MessageTapGestureRecognizer: UITapGestureRecognizer {
+            private let handler: () -> Void
+
+            init(handler: @escaping () -> Void) {
+                self.handler = handler
+                super.init(target: nil, action: nil)
+                addTarget(self, action: #selector(handleTap))
+            }
+
+            @objc private func handleTap() {
+                handler()
+            }
+        }
+
+        await MainActor.run {
+            SwiftMessages.show(config: config) {
+                let view = MessageView.viewFromNib(layout: .cardView)
+                view.configureTheme(.info)
+                view.configureContent(title: NSLocalizedString("notification", comment: ""), body: message)
+                view.button?.setTitle(NSLocalizedString("dismiss", comment: ""), for: .normal)
+                view.buttonTapHandler = { _ in SwiftMessages.hide() }
+
+                // Use closure-based tap gesture insteae of #selector
+                let tapGesture = MessageTapGestureRecognizer {
+                    Task {
+                        await self.messageViewTapped(action: action, cloudUserId: cloudUserId)
+                    }
+                }
+                view.addGestureRecognizer(tapGesture)
+
+                return view
+            }
+        }
+    }
+
+    // Action to be performed when the notification message view is tapped
+    func messageViewTapped(action: String?, cloudUserId: String? = nil) async {
+        notifyNotificationListeners(action: action, cloudUserId: cloudUserId)
+        SwiftMessages.hideAll()
+    }
+
+    // ✅ Ensure this runs on the MainActor
+    @MainActor
+    func notifyNotificationListeners(action: String?, cloudUserId: String? = nil) {
+        // Wake up screen saver immediately on incoming notification interaction
+        NotificationCenter.default.post(name: .wakeScreenSaver, object: nil)
+
+        if let navigationController = AppDelegate.appDelegate.window?.rootViewController as? UINavigationController,
+           let rootViewController = navigationController.viewControllers.first as? OpenHABRootViewController {
+            rootViewController.handleNotification(action: action, cloudUserId: cloudUserId)
+        }
+    }
+}
+
+extension UNUserNotificationCenter: @retroactive @unchecked Sendable {}
+extension UNNotificationResponse: @retroactive @unchecked Sendable {}
+extension UNNotification: @retroactive @unchecked Sendable {}


### PR DESCRIPTION
Reverts "Completion handler notification delegate instead of async version (#945)" (commit 1e2375de89477363ef02b02daa23bd2247d40883).

I had the new async version of the notification center delegate on my phone for five days now and conducted several notification tests, where I could not reproduce the crash observed in the previous async version. With the previous async version, the crash was fairly easy to provoke, it occurred most of the time when opening the application from a notification.