### PR TITLE
Fix for crash on number entry in input field

### DIFF
--- a/OpenHABCore/Package.swift
+++ b/OpenHABCore/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/onevcat/Kingfisher.git", from: "8.0.0"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-openapi-urlsession", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-openapi-urlsession", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-http-types.git", from: "1.0.0"),
         .package(url: "https://github.com/SDWebImage/SDWebImageSVGCoder.git", from: "1.4.0"),
         .package(url: "https://github.com/SFSafeSymbols/SFSafeSymbols.git", from: "6.2.0")

--- a/openHAB.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/openHAB.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -203,8 +203,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-openapi-runtime",
       "state" : {
-        "revision" : "23146bc8710ac5e57abb693113f02dc274cf39b6",
-        "version" : "1.8.0"
+        "revision" : "8f33cc5dfe81169fb167da73584b9c72c3e8bc23",
+        "version" : "1.8.2"
       }
     },
     {
@@ -212,8 +212,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-openapi-urlsession",
       "state" : {
-        "revision" : "9bf4c712ad7989d6a91dbe68748b8829a50837e4",
-        "version" : "1.0.2"
+        "revision" : "6fac6f7c428d5feea2639b5f5c8b06ddfb79434b",
+        "version" : "1.1.0"
       }
     },
     {

--- a/openHAB/OpenHABSitemapViewController.swift
+++ b/openHAB/OpenHABSitemapViewController.swift
@@ -837,7 +837,7 @@ extension OpenHABSitemapViewController: UITableViewDelegate, UITableViewDataSour
             // TODO: proper texts instead of hardcoded values
             let alert = UIAlertController(
                 title: "Enter new value",
-                message: "Current value for \(widget.labelText.orEmpty) is \(widget.labelValue.orEmpty)",
+                message: "Current value for \((widget.labelText.orEmpty.isEmpty ? "Unknown" : widget.labelText.orEmpty)) is \((widget.labelValue.orEmpty.isEmpty ? "Unknown" : widget.labelValue.orEmpty))",
                 preferredStyle: .alert
             )
             alert.addTextField(configurationHandler: textFieldAdder)

--- a/openHAB/OpenHABSitemapViewController.swift
+++ b/openHAB/OpenHABSitemapViewController.swift
@@ -837,12 +837,14 @@ extension OpenHABSitemapViewController: UITableViewDelegate, UITableViewDataSour
             // TODO: proper texts instead of hardcoded values
             let alert = UIAlertController(
                 title: "Enter new value",
-                message: "Current value for \(widget.label) is \(widget.state)",
+                message: "Current value for \(widget.labelText.orEmpty) is \(widget.labelValue.orEmpty)",
                 preferredStyle: .alert
             )
             alert.addTextField(configurationHandler: textFieldAdder)
             let sendAction = UIAlertAction(title: "Set value", style: .destructive) { [weak self] _ in
-                self?.sendCommand(widget.item, commandToSend: textExtractor(alert))
+                if let input = textExtractor(alert), !input.isEmpty {
+                    self?.sendCommand(widget.item, commandToSend: input)
+                }
             }
             alert.addAction(sendAction)
             alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))


### PR DESCRIPTION
TestFlight user reported crash on number entry in input field. Crash happened in Apple's swift-openapi-urlsession library. Update of library to version 1.1.0 was a first step. 
Further analysis revealed likely root cause.