### PR TITLE
Fix #973

### DIFF
--- a/openHAB/NewImageUITableViewCell.swift
+++ b/openHAB/NewImageUITableViewCell.swift
@@ -30,6 +30,7 @@ class NewImageUITableViewCell: GenericUITableViewCell, NoIconDisplayableCell {
     private var chartStyle: ChartStyle = .light
     private var activeTask: Task<Void, Never>?
     private var cachedImage: UIImage?
+    private var cachedWidgetId: String?
 
     var openHABRootUrl: String?
 
@@ -101,11 +102,38 @@ class NewImageUITableViewCell: GenericUITableViewCell, NoIconDisplayableCell {
         }
     }
 
+    override func prepareForReuse() {
+        super.prepareForReuse()
+
+        // Cancel any active image loading task
+        activeTask?.cancel()
+        activeTask = nil
+
+        // Invalidate and clear timer
+        refreshTimer?.invalidate()
+        refreshTimer = nil
+
+        // Clear cached image and widget ID to prevent showing wrong content in reused cells
+        cachedImage = nil
+        cachedWidgetId = nil
+        mainImageView?.image = nil
+
+        // Reset chart style
+        chartStyle = OHInterfaceStyle.current == .light ? ChartStyle.light : ChartStyle.dark
+    }
+
     override func displayWidget() {
-        if cachedImage == nil {
-            loadImage()
-        } else {
+        // Check if we can reuse the cached image for the same widget
+        let currentWidgetId = widget?.id
+        let canReuseCache = cachedImage != nil && cachedWidgetId == currentWidgetId
+
+        if canReuseCache {
             mainImageView.image = cachedImage
+        } else {
+            // Different widget, clear cache and load new image
+            cachedImage = nil
+            cachedWidgetId = currentWidgetId
+            loadImage()
         }
         // If widget have a refresh rate configured, i.e. different from zero, schedule an image update timer
         if widget.refresh != 0 {
@@ -129,6 +157,7 @@ class NewImageUITableViewCell: GenericUITableViewCell, NoIconDisplayableCell {
         switch widgetPayload {
         case let .embedded(image):
             cachedImage = image
+            cachedWidgetId = widget?.id
             mainImageView.image = image
             didLoad?()
         case let .link(url):
@@ -172,6 +201,7 @@ class NewImageUITableViewCell: GenericUITableViewCell, NoIconDisplayableCell {
                 let (data, _): (Data, URLResponse) = try await client.doRequest(baseURL: url, timeout: 10.0, type: .data, cacheingPolicy: !shouldCache ? .reloadIgnoringCacheData : .useProtocolCachePolicy)
                 await MainActor.run {
                     self.cachedImage = UIImage(data: data)
+                    self.cachedWidgetId = self.widget?.id
                     self.mainImageView?.image = self.cachedImage
                     self.didLoad?()
                 }
@@ -202,5 +232,6 @@ extension NewImageUITableViewCell: GenericCellCacheProtocol {
     func invalidateCache() {
         refreshTimer?.invalidate()
         cachedImage = nil
+        cachedWidgetId = nil
     }
 }

--- a/openHABWatch/Domain/UserData.swift
+++ b/openHABWatch/Domain/UserData.swift
@@ -154,7 +154,6 @@ final class UserData: ObservableObject {
 
     func startPageHandling(sitemapName: String, pageId: String = "") {
         // Don't clear widgets immediately when switching - use cached data during transition
-        let shouldPreserveWidgets = !widgets.isEmpty
         pageHandlingTask?.cancel()
 
         pageHandlingTask = Task {


### PR DESCRIPTION
Fix for #973 
cachedWidgetId - Tracks which widget's content is currently cached
Smart cache reuse - Only reloads when displaying a different widget Proper cleanup - Clears widget ID during prepareForReuse() and invalidateCache()