### PR TITLE
Remove reported source of unexplicable crashes

### DIFF
--- a/openHAB/OpenHABRootViewController.swift
+++ b/openHAB/OpenHABRootViewController.swift
@@ -561,7 +561,7 @@ class OpenHABRootViewController: UIViewController {
         }
     }
 
-    private func displayErrorNotification(_ message: String, completionHandler: (() -> Void)? = nil) {
+    private func displayErrorNotification(_ message: String) {
         let content = UNMutableNotificationContent()
         content.title = "Could not send command"
         content.body = message
@@ -571,11 +571,8 @@ class OpenHABRootViewController: UIViewController {
         let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
 
         // Schedule the request with the notification center
-        UNUserNotificationCenter.current().add(request) { error in
-            if let error {
-                print("Error scheduling notification: \(error.localizedDescription)")
-            }
-        }
+        // no error handler because it only printed and tended to crash in swift6
+        UNUserNotificationCenter.current().add(request)
     }
 
     private func httpCommandAction(_ command: String) {


### PR DESCRIPTION
There were two crashes while the app was in the background and a notification action was executed (or some time after that). The stacktraces are strange and point to a place where an error description is printed to the log and nothing more. So I removed that place and an unnecessary parameter in the function.