### PR TITLE
Handling of authentication challenges

### DIFF
--- a/openHABWatch/Extension/OpenHABWatchAppDelegate.swift
+++ b/openHABWatch/Extension/OpenHABWatchAppDelegate.swift
@@ -9,6 +9,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0
 
+import Kingfisher
 import OpenHABCore
 import os.log
 
@@ -76,4 +77,19 @@ extension OpenHABWatchAppDelegate: ClientCertificateManagerDelegate {
 
     // delegate should ask user for the export password used to decode the PKCS#12
     func alertClientCertificateError(_ clientCertificateManager: ClientCertificateManager?, errMsg: String) {}
+}
+
+// MARK: Kingfisher authentication with NSURLCredential
+
+extension OpenHABWatchAppDelegate: AuthenticationChallengeResponsible {
+    func downloader(_ downloader: ImageDownloader,
+                    didReceive challenge: URLAuthenticationChallenge) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+        await onReceiveSessionChallenge(with: challenge)
+    }
+
+    func downloader(_ downloader: ImageDownloader,
+                    task: URLSessionTask,
+                    didReceive challenge: URLAuthenticationChallenge) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+        await onReceiveSessionTaskChallenge(with: challenge)
+    }
 }

--- a/openHABWatch/Extension/OpenHABWatchAppDelegate.swift
+++ b/openHABWatch/Extension/OpenHABWatchAppDelegate.swift
@@ -79,7 +79,7 @@ extension OpenHABWatchAppDelegate: ClientCertificateManagerDelegate {
     func alertClientCertificateError(_ clientCertificateManager: ClientCertificateManager?, errMsg: String) {}
 }
 
-// MARK: Kingfisher authentication with NSURLCredential
+// MARK: Kingfisher authentication with URLCredential
 
 extension OpenHABWatchAppDelegate: AuthenticationChallengeResponsible {
     func downloader(_ downloader: ImageDownloader,

--- a/openHABWatch/OpenHABWatch.swift
+++ b/openHABWatch/OpenHABWatch.swift
@@ -9,6 +9,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0
 
+import Kingfisher
 import OpenHABCore
 import SFSafeSymbols
 import SwiftUI
@@ -18,7 +19,7 @@ import UserNotifications
 struct OpenHABWatch: App {
     @ObservedObject var settings = AppSettings.shared
     // https://developer.apple.com/documentation/watchkit/wkapplicationdelegate
-    @WKApplicationDelegateAdaptor(OpenHABWatchAppDelegate.self) var appDelegate
+    @WKApplicationDelegateAdaptor var appDelegate: OpenHABWatchAppDelegate
     @ObservedObject var userData = UserData.shared
 
     var body: some Scene {
@@ -44,6 +45,8 @@ struct OpenHABWatch: App {
                 _ = try? await center.requestAuthorization(
                     options: [.alert, .sound, .badge]
                 )
+                // Configure Kingfisher to use our app delegate for auth challenges
+                ImageDownloader.default.authenticationChallengeResponder = appDelegate
             }
         }
         WKNotificationScene(controller: NotificationController.self, category: "openHABNotification")


### PR DESCRIPTION
Add confirming to AuthenticationChallengeResponsible for watch app
Quick fix for #987. Will require more investigation for regression on handling of user response to authentication challenges 