### PR TITLE
Suggestion to make Items Search Field optional in Settings

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Util/Preferences.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/Preferences.swift
@@ -93,6 +93,7 @@ public struct HomePreferences: Codable, Equatable {
     public var defaultView = "web"
     public var demomode = true
     public var realTimeSliders = false
+    public var showSearchField = true
     public var iconType = 0
     public var defaultSitemap = "demo"
     public var sortSitemapsBy = 0
@@ -160,6 +161,9 @@ public actor Preferences {
 
     @UserDefault("idleOff", defaultValue: false)
     public var idleOff: Bool
+
+    @UserDefault("showSearchField", defaultValue: true)
+    public var showSearchField: Bool
 
     @UserDefault("screensaverEnabled", defaultValue: false)
     public var screensaverEnabled: Bool
@@ -376,6 +380,7 @@ public extension Preferences {
             currentHomePreferences.remoteConnectionConfig.ignoreSSL = UserDefaults.standard.object(forKey: "ignoreSSL") as? Bool ?? currentHomePreferences.remoteConnectionConfig.ignoreSSL
             currentHomePreferences.demomode = UserDefaults.standard.object(forKey: "demomode") as? Bool ?? currentHomePreferences.demomode
             currentHomePreferences.realTimeSliders = UserDefaults.standard.object(forKey: "realTimeSliders") as? Bool ?? currentHomePreferences.realTimeSliders
+            currentHomePreferences.showSearchField = UserDefaults.standard.object(forKey: "showSearchField") as? Bool ?? currentHomePreferences.showSearchField
             currentHomePreferences.iconType = UserDefaults.standard.object(forKey: "iconType") as? Int ?? currentHomePreferences.iconType
             currentHomePreferences.defaultSitemap = UserDefaults.standard.string(forKey: "defaultSitemap") ?? currentHomePreferences.defaultSitemap
         }
@@ -418,6 +423,7 @@ public extension Preferences {
             currentHomePreferences.defaultView = sharedDefaults.string(forKey: "defaultView") ?? currentHomePreferences.defaultView
             currentHomePreferences.demomode = sharedDefaults.object(forKey: "demomode") as? Bool ?? currentHomePreferences.demomode
             currentHomePreferences.realTimeSliders = sharedDefaults.object(forKey: "realTimeSliders") as? Bool ?? currentHomePreferences.realTimeSliders
+            currentHomePreferences.showSearchField = sharedDefaults.object(forKey: "showSearchField") as? Bool ?? currentHomePreferences.showSearchField
             currentHomePreferences.iconType = sharedDefaults.object(forKey: "iconType") as? Int ?? currentHomePreferences.iconType
             currentHomePreferences.defaultSitemap = sharedDefaults.string(forKey: "defaultSitemap") ?? currentHomePreferences.defaultSitemap
             currentHomePreferences.sortSitemapsBy = sharedDefaults.object(forKey: "sortSitemapsBy") as? Int ?? currentHomePreferences.sortSitemapsBy

--- a/openHAB/OpenHABSitemapViewController.swift
+++ b/openHAB/OpenHABSitemapViewController.swift
@@ -34,6 +34,7 @@ class OpenHABSitemapViewController: OpenHABViewController, UISearchControllerDel
     private var defaultSitemap = ""
     private var pageId = ""
     private var idleOff = false
+    private var showSearchField = false
     private var sitemaps: [OpenHABSitemap] = []
     private var currentPage: OpenHABPage?
     private var pageNetworkStatus: NetworkStatus?
@@ -86,18 +87,25 @@ class OpenHABSitemapViewController: OpenHABViewController, UISearchControllerDel
         refreshControl?.addTarget(self, action: #selector(handleRefresh(_:)), for: .valueChanged)
         widgetTableView.refreshControl = refreshControl
 
-        // Setup search controller
-        searchController.searchResultsUpdater = self
-        searchController.obscuresBackgroundDuringPresentation = false
-        searchController.searchBar.autocapitalizationType = .none
-        searchController.searchBar.delegate = self
-        searchController.delegate = self
-        searchController.searchBar.placeholder = NSLocalizedString("search_items", comment: "")
-        definesPresentationContext = true
+        // Load showSearchField settinsg
+        showSearchField = Preferences.shared.currentHomePreferences.showSearchField
 
-        // Assign to navigation item (must be in navigation stack)
-        navigationItem.searchController = searchController
-        navigationItem.hidesSearchBarWhenScrolling = false
+        if showSearchField {
+            // Setup search controller
+            searchController.searchResultsUpdater = self
+            searchController.obscuresBackgroundDuringPresentation = false
+            searchController.searchBar.autocapitalizationType = .none
+            searchController.searchBar.delegate = self
+            searchController.delegate = self
+            searchController.searchBar.placeholder = NSLocalizedString("search_items", comment: "")
+            definesPresentationContext = true
+
+            // Assign to navigation item (must be in navigation stack)
+            navigationItem.searchController = searchController
+            navigationItem.hidesSearchBarWhenScrolling = false
+        } else {
+            navigationItem.searchController = nil
+        }
 
         // Setup active connection
         guard let config = activeConnectionInfo?.configuration else { return }
@@ -120,9 +128,16 @@ class OpenHABSitemapViewController: OpenHABViewController, UISearchControllerDel
         Logger.sitemapViewController.info("OpenHABSitemapViewController viewDidAppear")
         super.viewDidAppear(animated)
 
-        if parent?.navigationItem.searchController !== searchController {
-            parent?.navigationItem.searchController = searchController
-            parent?.navigationItem.hidesSearchBarWhenScrolling = true
+        // Load showSearchField settinsg
+        showSearchField = Preferences.shared.currentHomePreferences.showSearchField
+
+        if showSearchField {
+            if parent?.navigationItem.searchController !== searchController {
+                parent?.navigationItem.searchController = searchController
+                parent?.navigationItem.hidesSearchBarWhenScrolling = true
+            }
+        } else {
+            parent?.navigationItem.searchController = nil
         }
     }
 
@@ -313,7 +328,7 @@ extension OpenHABSitemapViewController {
     func updateUI(with page: OpenHABPage) {
         currentPage = page
 
-        if isFiltering {
+        if showSearchField, isFiltering {
             filterContentForSearchText(searchController.searchBar.text)
         }
 

--- a/openHAB/Resources/de.lproj/Localizable.strings
+++ b/openHAB/Resources/de.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "client_certificates" = "Client-Zertifikate";
 "disable_idle_timeout" = "Bildschirm-Timeout deaktivieren";
 "real_time_sliders" = "Echtzeitschieberegler";
+"show_search_field" = "Suchfeld anzeigen";
 "clear_image_cache" = "Zwischenspeicher für Bilder leeren";
 "clear_web_cache" = "Webcache leeren";
 "cache_cleared" = "Cache gelöscht";

--- a/openHAB/Resources/en.lproj/Localizable.strings
+++ b/openHAB/Resources/en.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "client_certificates" = "Client Certificates";
 "disable_idle_timeout" = "Disable Idle Timeout";
 "real_time_sliders" = "Real-time Sliders";
+"show_search_field" = "Show Search Field";
 "clear_image_cache" = "Clear Image Cache";
 "clear_web_cache" = "Clear Web Cache";
 "cache_cleared" = "Cache Cleared";

--- a/openHAB/Resources/es.lproj/Localizable.strings
+++ b/openHAB/Resources/es.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "client_certificates" = "Certificados de cliente";
 "disable_idle_timeout" = "Desactivar tiempo de espera de inactividad";
 "real_time_sliders" = "Deslizadores en tiempo real";
+"show_search_field" = "Show Search Field";
 "clear_image_cache" = "Limpiar caché de imágenes";
 "clear_web_cache" = "Limpiar caché web";
 "cache_cleared" = "Caché limpiada";

--- a/openHAB/Resources/fi.lproj/Localizable.strings
+++ b/openHAB/Resources/fi.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "client_certificates" = "Client Certificates";
 "disable_idle_timeout" = "Disable Idle Timeout";
 "real_time_sliders" = "Real-time Sliders";
+"show_search_field" = "Show Search Field";
 "clear_image_cache" = "Clear Image Cache";
 "clear_web_cache" = "Clear Web Cache";
 "cache_cleared" = "Cache Cleared";

--- a/openHAB/Resources/fr.lproj/Localizable.strings
+++ b/openHAB/Resources/fr.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "client_certificates" = "Certificats du client";
 "disable_idle_timeout" = "Désactiver le délai d'inactivité";
 "real_time_sliders" = "Curseurs en temps réel";
+"show_search_field" = "Show Search Field";
 "clear_image_cache" = "Vider le cache des images";
 "clear_web_cache" = "Vider le cache Web";
 "cache_cleared" = "Cache effacé";

--- a/openHAB/Resources/it.lproj/Localizable.strings
+++ b/openHAB/Resources/it.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "client_certificates" = "Certificati Client";
 "disable_idle_timeout" = "Disabilita Timeout Inattività";
 "real_time_sliders" = "Cursori In Tempo Reale";
+"show_search_field" = "Show Search Field";
 "clear_image_cache" = "Pulisci Cache Immagini";
 "clear_web_cache" = "Svuota memoria cache Web";
 "cache_cleared" = "Cache svuotata";

--- a/openHAB/Resources/nb.lproj/Localizable.strings
+++ b/openHAB/Resources/nb.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "client_certificates" = "Klientsertifikater";
 "disable_idle_timeout" = "Deaktiver Tidsavbrudd for Inaktivitet";
 "real_time_sliders" = "Sanntids Skyveknapper";
+"show_search_field" = "Show Search Field";
 "clear_image_cache" = "Tøm Hurtigbuffer for Bilder";
 "clear_web_cache" = "Clear Web Cache";
 "cache_cleared" = "Cache Cleared";

--- a/openHAB/Resources/nl.lproj/Localizable.strings
+++ b/openHAB/Resources/nl.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "client_certificates" = "Cliëntcertificaat";
 "disable_idle_timeout" = "Schermtimeout uitschakelen";
 "real_time_sliders" = "Realtime schuifregelaars";
+"show_search_field" = "Show Search Field";
 "clear_image_cache" = "Leeg de afbeeldingencache";
 "clear_web_cache" = "Wis webcache";
 "cache_cleared" = "Cache gewist";

--- a/openHAB/Resources/ru.lproj/Localizable.strings
+++ b/openHAB/Resources/ru.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "client_certificates" = "Client Certificates";
 "disable_idle_timeout" = "Disable Idle Timeout";
 "real_time_sliders" = "Real-time Sliders";
+"show_search_field" = "Show Search Field";
 "clear_image_cache" = "Clear Image Cache";
 "clear_web_cache" = "Clear Web Cache";
 "cache_cleared" = "Cache Cleared";

--- a/openHAB/SettingsView/SettingsView.swift
+++ b/openHAB/SettingsView/SettingsView.swift
@@ -18,6 +18,7 @@ struct SettingsView: View {
     @State var settingsDemomode = false
     @State var settingsIdleOff = true
     @State var settingsRealTimeSliders = true
+    @State var settingsShowSearchField = true
     @State var settingsSendCrashReports = false
     @State var settingsIconType: IconType = .svg
     @State var settingsSortSitemapsBy: SortSitemapsOrder = .label
@@ -54,6 +55,7 @@ struct SettingsView: View {
 
             SitemapSettingsView(
                 settingsRealTimeSliders: $settingsRealTimeSliders,
+                settingsShowSearchField: $settingsShowSearchField,
                 settingsIconType: $settingsIconType,
                 settingsSortSitemapsBy: $settingsSortSitemapsBy,
                 settingsSitemapForWatch: $settingsSitemapForWatch,
@@ -120,6 +122,7 @@ struct SettingsView: View {
         settingsDemomode = Preferences.shared.currentHomePreferences.demomode
         settingsIdleOff = Preferences.shared.idleOff
         settingsRealTimeSliders = Preferences.shared.currentHomePreferences.realTimeSliders
+        settingsShowSearchField = Preferences.shared.currentHomePreferences.showSearchField
         settingsSendCrashReports = Preferences.shared.sendCrashReports
         settingsIconType = IconType(rawValue: Preferences.shared.currentHomePreferences.iconType) ?? .svg
         settingsSortSitemapsBy = SortSitemapsOrder(rawValue: Preferences.shared.currentHomePreferences.sortSitemapsBy) ?? .label
@@ -136,6 +139,7 @@ struct SettingsView: View {
         Preferences.shared.modifyActiveHome { @MainActor homePreferences in
             homePreferences.demomode = settingsDemomode
             homePreferences.realTimeSliders = settingsRealTimeSliders
+            homePreferences.showSearchField = settingsShowSearchField
             homePreferences.iconType = settingsIconType.rawValue
             homePreferences.sortSitemapsBy = settingsSortSitemapsBy.rawValue
             homePreferences.alwaysAllowWebRTC = settingsAlwaysAllowWebRTC
@@ -171,6 +175,7 @@ extension UIApplication {
         @State var settingsDemomode = false
         @State var settingsIdleOff = true
         @State var settingsRealTimeSliders = true
+        @State var settingsShowSearchField = true
         @State var settingsSendCrashReports = false
         @State var settingsIconType: IconType = .svg
         @State var settingsSortSitemapsBy: SortSitemapsOrder = .label
@@ -210,6 +215,7 @@ extension UIApplication {
                     settingsDemomode: settingsDemomode,
                     settingsIdleOff: settingsIdleOff,
                     settingsRealTimeSliders: settingsRealTimeSliders,
+                    settingsShowSearchField: settingsShowSearchField,
                     settingsSendCrashReports: settingsSendCrashReports,
                     settingsIconType: settingsIconType,
                     settingsSortSitemapsBy: settingsSortSitemapsBy,

--- a/openHAB/SettingsView/SitemapSettingsView.swift
+++ b/openHAB/SettingsView/SitemapSettingsView.swift
@@ -16,6 +16,7 @@ import SwiftUI
 
 struct SitemapSettingsView: View {
     @Binding var settingsRealTimeSliders: Bool
+    @Binding var settingsShowSearchField: Bool
     @Binding var settingsIconType: IconType
     @Binding var settingsSortSitemapsBy: SortSitemapsOrder
     @Binding var settingsSitemapForWatch: String
@@ -27,6 +28,10 @@ struct SitemapSettingsView: View {
         Section(header: Text(LocalizedStringKey("sitemap_settings"))) {
             Toggle(isOn: $settingsRealTimeSliders) {
                 Text("Real-time Sliders")
+            }
+
+            Toggle(isOn: $settingsShowSearchField) {
+                Text("Show Search Field")
             }
 
             Button {
@@ -82,6 +87,7 @@ struct SitemapSettingsView: View {
 #Preview {
     struct PreviewWrapper: View {
         @State var realTimeSliders = true
+        @State var showSearchField = true
         @State var iconType: IconType = .svg
         @State var sortSitemapsBy: SortSitemapsOrder = .label
         @State var sitemapForWatch = "Home"
@@ -106,6 +112,7 @@ struct SitemapSettingsView: View {
                 Form {
                     SitemapSettingsView(
                         settingsRealTimeSliders: $realTimeSliders,
+                        settingsShowSearchField: $showSearchField,
                         settingsIconType: $iconType,
                         settingsSortSitemapsBy: $sortSitemapsBy,
                         settingsSitemapForWatch: $sitemapForWatch,


### PR DESCRIPTION
While on pre-iOS 26 the items search field located at the top vanishes underneath the title bar, in iOS 26 it is constantly visible at the bottom of the view, always overlapping the last rows of the sitemap. For anyone not using the search very often making the search field optional in the settings will always give them an unobstructed view of their sitemap.

<img width="603" height="1311" alt="Simulator Screenshot - My iPhone 17 - 2025-10-30 at 18 35 07" src="https://github.com/user-attachments/assets/9ba8afc6-1957-44b7-adc9-1b0cf0f70949" />


<img width="603" height="1311" alt="Simulator Screenshot - My iPhone 17 - 2025-10-30 at 18 35 24" src="https://github.com/user-attachments/assets/ce9beb94-a7b8-4be7-8c6b-bacc4cb0d4f7" />


<img width="603" height="1311" alt="Simulator Screenshot - My iPhone 17 - 2025-10-30 at 18 34 30" src="https://github.com/user-attachments/assets/aede00ec-b513-491b-9dbc-2a4f064e9265" />
