### PR TITLE
watchOS Scrolling behavior

### DIFF
--- a/openHABWatch/Domain/UserData.swift
+++ b/openHABWatch/Domain/UserData.swift
@@ -197,11 +197,14 @@ final class UserData: ObservableObject {
         currentlyLoadingSitemap = sitemapName
 
         pageHandlingTask = Task {
+            let taskSitemapName = sitemapName  // Capture the sitemap name for this specific task
             defer {
-                // Always clear task references when task completes (cancelled or error)
+                // Only clear references if this task is still the current one
                 Task { @MainActor in
-                    self.pageHandlingTask = nil
-                    self.currentlyLoadingSitemap = nil
+                    if self.currentlyLoadingSitemap == taskSitemapName {
+                        self.pageHandlingTask = nil
+                        self.currentlyLoadingSitemap = nil
+                    }
                 }
             }
 

--- a/openHABWatch/Domain/UserData.swift
+++ b/openHABWatch/Domain/UserData.swift
@@ -106,11 +106,10 @@ final class UserData: ObservableObject {
             .store(in: &cancellables)
 
         // Observe sitemap changes - reload the sitemap when it changes
-        // Note: We don't use .dropFirst() here because we need to catch the initial value
-        // when the app context is first received from the iOS app
         AppSettings.shared.$sitemapForWatch
+            .dropFirst()
             .removeDuplicates()
-            .debounce(for: .seconds(0.3), scheduler: RunLoop.main)
+            .debounce(for: .seconds(2.0), scheduler: RunLoop.main)
             .sink { [weak self] newValue in
                 guard !newValue.isEmpty else { return }
                 Task { @MainActor in
@@ -220,8 +219,7 @@ final class UserData: ObservableObject {
                         Task { await self?.sendCommand(item, command: command) }
                     }
                     self.openHABSitemapPage = initialPage
-                    var newWidgets = [OpenHABWidget]()
-                    newWidgets.flatten(initialPage?.widgets ?? [])
+                    let newWidgets = initialPage?.widgets ?? []
                     self.widgets = newWidgets
                     if !newWidgets.isEmpty {
                         self.cachedWidgets = newWidgets
@@ -244,8 +242,7 @@ final class UserData: ObservableObject {
                                 Task { await self?.sendCommand(item, command: command) }
                             }
                             self.openHABSitemapPage = page
-                            var newWidgets = [OpenHABWidget]()
-                            newWidgets.flatten(page?.widgets ?? [])
+                            let newWidgets = page?.widgets ?? []
                             self.widgets = newWidgets
                             if !newWidgets.isEmpty {
                                 self.cachedWidgets = newWidgets

--- a/openHABWatch/Views/Rows/SwitchRow.swift
+++ b/openHABWatch/Views/Rows/SwitchRow.swift
@@ -39,7 +39,7 @@ struct SwitchRow: View {
             HStack {
                 IconView(widget: widget, settings: settings)
                 VStack {
-                    TextLabelView(widget: widget)
+                    TextLabelView(widget: widget, lineLimit: 1)
                     DetailTextLabelView(widget: widget)
                 }
             }

--- a/openHABWatch/Views/SitemapPageView.swift
+++ b/openHABWatch/Views/SitemapPageView.swift
@@ -32,7 +32,7 @@ struct SitemapPageView: View {
                     }
                 } else if !viewModel.widgets.isEmpty {
                     ScrollView {
-                        LazyVStack {
+                        VStack(spacing: 4) {
                             ForEach(viewModel.widgets) { widget in
                                 rowWidget(widget: widget)
                                     .id(widget.widgetId)
@@ -51,6 +51,7 @@ struct SitemapPageView: View {
                                 .padding(.horizontal)
                             }
                         }
+                        .padding(.vertical, 2)
                     }
                     .scrollPosition(id: $scrollPosition, anchor: .top)
                     .navigationBarTitle(viewModel.openHABSitemapPage?.title ?? "Sitemap")


### PR DESCRIPTION
  * Scrolling behavior - Changed from LazyVStack to VStack in SitemapPageView.swift to ensure widgets render properly when scrolling
  * Widget duplication - Removed flatten() calls to prevent widgets appearing twice
  * Spontaneous sitemap switching - Fixed the race condition in the defer block in UserData.swiftso that cancelled tasks don't interfere with newly started tasks