### PR TITLE
Fix flaky CertificateStoreTests and NetworkTrackerTests

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Util/HTTPClient.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/HTTPClient.swift
@@ -68,11 +68,11 @@ public actor CertificateStore {
     public static let shared = CertificateStore()
 
     private var trustedCertificates: [String: CertificateEntry] = [:]
+    private let persistencePath: URL?
 
+    /// Creates a CertificateStore with the default persistence path (app group or documents directory)
     public init() {
-        Logger.httpClient.info("Initializing cert store")
-
-        // Inline the path calculation to avoid nonisolated issues
+        // Calculate the default persistence path
         let path: URL
         #if os(watchOS)
         let documentsDirectory = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
@@ -88,33 +88,67 @@ public actor CertificateStore {
         }
         #endif
 
-        // Load certificates directly in init
+        persistencePath = path
+        let (certificates, needsMigration) = Self.loadCertificates(from: path)
+        trustedCertificates = certificates
+
+        // If migration occurred, persist the new format
+        if needsMigration {
+            Task {
+                await self.saveTrustedCertificates()
+                Logger.httpClient.info("Migration completed, saved in new format")
+            }
+        }
+    }
+
+    /// Creates a CertificateStore for testing with an optional custom persistence path.
+    /// Pass `nil` for in-memory only operation (no file I/O).
+    public init(persistencePath: URL?) {
+        self.persistencePath = persistencePath
+        if let path = persistencePath {
+            let (certificates, needsMigration) = Self.loadCertificates(from: path)
+            trustedCertificates = certificates
+
+            // If migration occurred, persist the new format
+            if needsMigration {
+                Task {
+                    await self.saveTrustedCertificates()
+                    Logger.httpClient.info("Migration completed, saved in new format")
+                }
+            }
+        } else {
+            trustedCertificates = [:]
+        }
+    }
+
+    /// Loads certificates from a given path (static to be called from init)
+    /// Returns a tuple of (certificates, needsMigration) where needsMigration indicates if the data was in an old format
+    private static func loadCertificates(from path: URL) -> (certificates: [String: CertificateEntry], needsMigration: Bool) {
+        Logger.httpClient.info("Initializing cert store")
         Logger.httpClient.debug("Attempting to load certificates from \(path)")
+
         do {
             let rawdata = try Data(contentsOf: path)
             let decoder = PropertyListDecoder()
 
             // Try to load new format first
             do {
-                trustedCertificates = try decoder.decode([String: CertificateEntry].self, from: rawdata)
-                let certCount = trustedCertificates.count
+                let certificates = try decoder.decode([String: CertificateEntry].self, from: rawdata)
+                let certCount = certificates.count
                 Logger.httpClient.info("Loaded existing cert store (new format) with \(certCount) certificates")
+                return (certificates, false)
             } catch {
-                // Fall back to old format and migrate
+                // Fall back to old format
                 let oldFormat = try decoder.decode([String: Data].self, from: rawdata)
                 Logger.httpClient.info("Migrating cert store from old format with \(oldFormat.count) certificates")
 
                 // Convert old format to new format with current date
                 let migrationDate = Date()
+                var certificates: [String: CertificateEntry] = [:]
                 for (domain, data) in oldFormat {
-                    trustedCertificates[domain] = CertificateEntry(data: data, dateAccepted: migrationDate)
+                    certificates[domain] = CertificateEntry(data: data, dateAccepted: migrationDate)
                 }
-
-                // Schedule save for after init completes
-                Task {
-                    await self.saveTrustedCertificates()
-                    Logger.httpClient.info("Migration completed, will save in new format")
-                }
+                return (certificates, true)
             }
         } catch {
             // if Decodable fails, fall back to NSKeyedArchiver for very old format
@@ -125,45 +159,28 @@ public actor CertificateStore {
 
                     // Convert old format to new format with current date
                     let migrationDate = Date()
+                    var certificates: [String: CertificateEntry] = [:]
                     for (domain, data) in unarchivedTrustedCertificates {
-                        trustedCertificates[domain] = CertificateEntry(data: data, dateAccepted: migrationDate)
+                        certificates[domain] = CertificateEntry(data: data, dateAccepted: migrationDate)
                     }
-
-                    // Schedule save for after init completes
-                    Task {
-                        await self.saveTrustedCertificates()
-                        Logger.httpClient.info("Migration from NSKeyedArchiver completed")
-                    }
-                } else {
-                    trustedCertificates = [:]
+                    return (certificates, true)
                 }
             } catch {
-                trustedCertificates = [:]
+                // File doesn't exist or can't be read
             }
             Logger.httpClient.info("No cert store, creating")
+            return ([:], false)
         }
-    }
-
-    private func getPersistencePath() -> URL {
-        #if os(watchOS)
-        let documentsDirectory = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
-        return URL(fileURLWithPath: documentsDirectory).appendingPathComponent("trustedCertificates")
-        #else
-        // Try app group container first, fall back to documents directory for testing
-        if let appGroupURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.org.openhab.app") {
-            return appGroupURL.appendingPathComponent("trustedCertificates")
-        } else {
-            // Fallback for test environment where app group may not be available
-            let documentsDirectory = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
-            return URL(fileURLWithPath: documentsDirectory).appendingPathComponent("trustedCertificates")
-        }
-        #endif
     }
 
     private func saveTrustedCertificates() async {
+        guard let path = persistencePath else {
+            // In-memory mode, no persistence
+            return
+        }
+
         do {
             let data = try PropertyListEncoder().encode(trustedCertificates)
-            let path = getPersistencePath()
 
             // Ensure parent directory exists
             let parentDir = path.deletingLastPathComponent()

--- a/OpenHABCore/Tests/OpenHABCoreTests/CertificateStoreTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/CertificateStoreTests.swift
@@ -18,19 +18,28 @@ import Testing
 struct CertificateStoreTests {
     // Helper to load the bundled test certificate data
     func loadTestCertificateData() throws -> Data {
-        let certURL = Bundle.module.url(forResource: "test-cert", withExtension: "cer")!
+        guard let certURL = Bundle.module.url(forResource: "test-cert", withExtension: "cer") else {
+            throw CertificateStoreTestError.resourceNotFound("test-cert.cer")
+        }
         return try Data(contentsOf: certURL)
     }
 
-    // Helper to create a fresh store (actor) instance
-    func makeStore() -> CertificateStore {
-        CertificateStore.shared
+    // Helper to create a fresh in-memory store for isolated testing
+    func makeInMemoryStore() -> CertificateStore {
+        CertificateStore(persistencePath: nil)
     }
 
-    @Test("Store and retrieve certificate")
+    // Helper to create a unique temporary path for persistence tests
+    func makeTempPersistencePath() -> URL {
+        let tempDir = FileManager.default.temporaryDirectory
+        let uniqueID = UUID().uuidString
+        return tempDir.appendingPathComponent("CertificateStoreTests-\(uniqueID)")
+    }
+
+    @Test("Store and retrieve certificate", .timeLimit(.minutes(1)))
     func storeAndRetrieve() async throws {
         let domain = "store-retrieve-test.openhab.org"
-        let store = makeStore()
+        let store = makeInMemoryStore()
 
         let data = try loadTestCertificateData()
         await store.storeCertificateData(data, forDomain: domain)
@@ -43,14 +52,12 @@ struct CertificateStoreTests {
         #expect(info != nil)
         #expect(info?.data == data)
         #expect(info!.dateAccepted.timeIntervalSinceNow > -5) // stored just now
-
-        await store.removeCertificate(forDomain: domain)
     }
 
-    @Test("Overwrite existing certificate updates data and date")
+    @Test("Overwrite existing certificate updates data and date", .timeLimit(.minutes(1)))
     func overwriteUpdates() async throws {
         let domain = "overwrite-test.openhab.org"
-        let store = makeStore()
+        let store = makeInMemoryStore()
 
         let first = Data([0x01, 0x02, 0x03])
         await store.storeCertificateData(first, forDomain: domain)
@@ -66,14 +73,12 @@ struct CertificateStoreTests {
         #expect(info != nil)
         #expect(info!.data == second)
         #expect(info!.dateAccepted >= firstDate)
-
-        await store.removeCertificate(forDomain: domain)
     }
 
-    @Test("Remove certificate clears entry")
+    @Test("Remove certificate clears entry", .timeLimit(.minutes(1)))
     func removeClears() async throws {
         let domain = "remove-test.openhab.org"
-        let store = makeStore()
+        let store = makeInMemoryStore()
 
         let data = Data([0xAA, 0xBB])
         await store.storeCertificateData(data, forDomain: domain)
@@ -86,10 +91,10 @@ struct CertificateStoreTests {
         #expect(info == nil)
     }
 
-    @Test("Store nil removes certificate")
+    @Test("Store nil removes certificate", .timeLimit(.minutes(1)))
     func storeNilRemoves() async throws {
         let domain = "nil-remove-test.openhab.org"
-        let store = makeStore()
+        let store = makeInMemoryStore()
 
         let data = Data([0xDE, 0xAD, 0xBE, 0xEF])
         await store.storeCertificateData(data, forDomain: domain)
@@ -97,15 +102,13 @@ struct CertificateStoreTests {
 
         await store.storeCertificateData(nil, forDomain: domain)
         #expect(await store.certificateData(forDomain: domain) == nil)
-
-        await store.removeCertificate(forDomain: domain)
     }
 
-    @Test("Get all certificates returns expected entries")
+    @Test("Get all certificates returns expected entries", .timeLimit(.minutes(1)))
     func getAllCertificates() async throws {
         let domainA = "list-a-test.openhab.org"
         let domainB = "list-b-test.openhab.org"
-        let store = makeStore()
+        let store = makeInMemoryStore()
 
         let dataA = Data([0x01])
         let dataB = Data([0x02])
@@ -117,29 +120,37 @@ struct CertificateStoreTests {
         #expect(all[domainB]?.data == dataB)
         #expect(all.keys.contains(domainA))
         #expect(all.keys.contains(domainB))
-
-        await store.removeCertificate(forDomain: domainA)
-        await store.removeCertificate(forDomain: domainB)
     }
 
-    @Test("Persistence across instances")
+    @Test("Persistence across instances", .timeLimit(.minutes(1)))
     func persistenceAcrossInstances() async throws {
         let domain = "persistence-test.openhab.org"
-        var store: CertificateStore? = makeStore()
+        let tempPath = makeTempPersistencePath()
 
-        Logger.defaultLoggingMiddleware.log("Running persistenceAcrossInstances")
-        let data = Data([0xFE, 0xED, 0xFA, 0xCE])
-        await store!.storeCertificateData(data, forDomain: domain)
+        // Clean up any existing file
+        try? FileManager.default.removeItem(at: tempPath)
 
-        // Ensure the store is completely finished with file operations
-        // by setting it to nil and waiting a moment
-        store = nil
+        do {
+            // Create first store instance with temp path
+            let store1 = CertificateStore(persistencePath: tempPath)
 
-        // Create a new instance which should load from disk
-        store = makeStore()
-        let fetched = await store!.certificateData(forDomain: domain)
-        #expect(fetched == data, "Certificate data should persist across instances")
+            Logger.defaultLoggingMiddleware.log("Running persistenceAcrossInstances")
+            let data = Data([0xFE, 0xED, 0xFA, 0xCE])
+            await store1.storeCertificateData(data, forDomain: domain)
 
-        await store?.removeCertificate(forDomain: domain)
+            // Create a new instance which should load from disk
+            let store2 = CertificateStore(persistencePath: tempPath)
+            let fetched = await store2.certificateData(forDomain: domain)
+            #expect(fetched == data, "Certificate data should persist across instances")
+        }
+
+        // Clean up temp file
+        try? FileManager.default.removeItem(at: tempPath)
     }
+}
+
+// MARK: - Test Errors
+
+enum CertificateStoreTestError: Error {
+    case resourceNotFound(String)
 }

--- a/OpenHABCore/Tests/OpenHABCoreTests/NetworkTrackerTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/NetworkTrackerTests.swift
@@ -97,6 +97,9 @@ final actor MockOpenAPIService: OpenAPIServiceProtocol {
 
 actor PathMonitor {
     var handler: ((Bool) -> Void)?
+    private var monitoringStarted = false
+    private var waitingContinuations: [CheckedContinuation<Void, Never>] = []
+
     func connectionUpdates() -> AsyncStream<Bool> {
         AsyncStream { continuation in
             handler = { connectionStatus in
@@ -105,15 +108,36 @@ actor PathMonitor {
         }
     }
 
+    func signalMonitoringStarted() {
+        monitoringStarted = true
+        // Resume all waiting continuations
+        for continuation in waitingContinuations {
+            continuation.resume()
+        }
+        waitingContinuations.removeAll()
+    }
+
+    func waitForMonitoringStarted() async {
+        if monitoringStarted {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waitingContinuations.append(continuation)
+        }
+    }
+
     func changeState(_ state: Bool) {
         handler?(state)
     }
 }
 
-final class MockPathMonitor: NWPathMonitoring {
+final class MockPathMonitor: NWPathMonitoring, @unchecked Sendable {
     private let monitor: PathMonitor = .init()
 
     func startMonitoring(handler: @escaping (Bool) async -> Void) async {
+        // Signal that monitoring has started before entering the loop
+        await monitor.signalMonitoringStarted()
+
         for await connected in await monitor.connectionUpdates() {
             await handler(connected)
         }
@@ -123,12 +147,14 @@ final class MockPathMonitor: NWPathMonitoring {
         // no-op
     }
 
+    /// Waits until startMonitoring has been called
+    func waitForMonitoringToStart() async {
+        await monitor.waitForMonitoringStarted()
+    }
+
     /// Call this in your tests to simulate a connection status change
-    func simulateConnection(isConnected: Bool) {
-        let monitor = monitor
-        Task.detached {
-            await monitor.changeState(isConnected)
-        }
+    func simulateConnection(isConnected: Bool) async {
+        await monitor.changeState(isConnected)
     }
 }
 
@@ -178,11 +204,19 @@ final class NetworkTrackerTests: XCTestCase {
         // Wait for the stream to actually start iterating before triggering any state changes
         await fulfillment(of: [streamIterating], timeout: 1.0)
 
+        // Start a task to wait for monitoring to begin
+        let monitoringTask = Task {
+            await mockMonitor.waitForMonitoringToStart()
+        }
+
         // Start tracking with your mock config
         await networkTracker.startTracking(connectionConfigurations: [config])
 
+        // Wait for path monitor's startMonitoring to be called before simulating connection
+        await monitoringTask.value
+
         // Simulate the network becoming available
-        mockMonitor.simulateConnection(isConnected: true)
+        await mockMonitor.simulateConnection(isConnected: true)
 
         await fulfillment(of: [connectedExpectation], timeout: 2.0)
         statusTask.cancel()


### PR DESCRIPTION
The storeAndRetrieve test was timing out in CI due to:
- Shared singleton performing slow file I/O with ASAN enabled
- No test isolation between test cases
- No timeout protection

Changes:
- Add testable init(persistencePath:) to CertificateStore for in-memory mode
- Update tests to use isolated in-memory instances instead of singleton
- Add .timeLimit(.minutes(1)) to all tests to prevent indefinite hangs
- Use unique temp paths for persistence test with proper cleanup