### PR TITLE
Segmented Controls layout adjustments for iPads

### DIFF
--- a/openHAB/SwiftUI/Rows/SegmentedRowView.swift
+++ b/openHAB/SwiftUI/Rows/SegmentedRowView.swift
@@ -75,7 +75,6 @@ private struct SegmentedRowContent: View {
                         Spacer(minLength: 8)
                     }
                     let leadingPadding: CGFloat = input.displayState.labelValue.isNilOrEmpty ? 0 : 8
-
                     // Button-based segmented control with animated selection indicator
                     segmentedButtons(mappings: input.mappings, selectedIndex: selectedIndex, displayState: input.displayState, widgetVersion: widgetVersion)
                         .frame(minWidth: 75)

--- a/openHAB/SwiftUI/Rows/SegmentedRowView.swift
+++ b/openHAB/SwiftUI/Rows/SegmentedRowView.swift
@@ -71,10 +71,14 @@ private struct SegmentedRowContent: View {
                         .fixedSize(horizontal: true, vertical: false)
                         .padding(.leading, 8)
                 } else {
+                    if input.displayState.labelValue.isNilOrEmpty {
+                        Spacer(minLength: 8)
+                    }
+                    let leadingPadding: CGFloat = input.displayState.labelValue.isNilOrEmpty ? 0 : 8
                     // Button-based segmented control with animated selection indicator
                     segmentedButtons(mappings: input.mappings, selectedIndex: selectedIndex, displayState: input.displayState, widgetVersion: widgetVersion)
                         .frame(minWidth: 75)
-                        .padding(.leading, 8)
+                        .padding(.leading, leadingPadding)
                         .layoutPriority(1)
                 }
             }

--- a/openHAB/SwiftUI/Rows/SegmentedRowView.swift
+++ b/openHAB/SwiftUI/Rows/SegmentedRowView.swift
@@ -71,10 +71,15 @@ private struct SegmentedRowContent: View {
                         .fixedSize(horizontal: true, vertical: false)
                         .padding(.leading, 8)
                 } else {
+                    if input.displayState.labelValue.isNilOrEmpty {
+                        Spacer(minLength: 8)
+                    }
+                    let leadingPadding: CGFloat = input.displayState.labelValue.isNilOrEmpty ? 0 : 8
+
                     // Button-based segmented control with animated selection indicator
                     segmentedButtons(mappings: input.mappings, selectedIndex: selectedIndex, displayState: input.displayState, widgetVersion: widgetVersion)
                         .frame(minWidth: 75)
-                        .padding(.leading, 8)
+                        .padding(.leading, leadingPadding)
                         .layoutPriority(1)
                 }
             }

--- a/openHAB/SwiftUI/Rows/SegmentedRowView.swift
+++ b/openHAB/SwiftUI/Rows/SegmentedRowView.swift
@@ -75,6 +75,7 @@ private struct SegmentedRowContent: View {
                         Spacer(minLength: 8)
                     }
                     let leadingPadding: CGFloat = input.displayState.labelValue.isNilOrEmpty ? 0 : 8
+
                     // Button-based segmented control with animated selection indicator
                     segmentedButtons(mappings: input.mappings, selectedIndex: selectedIndex, displayState: input.displayState, widgetVersion: widgetVersion)
                         .frame(minWidth: 75)


### PR DESCRIPTION
Currently 
<img width="790" height="497" alt="Screenshot 2026-02-24 at 20 19 50" src="https://github.com/user-attachments/assets/8cca8af1-9953-4d3a-8e97-6ea848cde7d3" />

<img width="756" height="198" alt="Screenshot 2026-02-24 at 20 19 18" src="https://github.com/user-attachments/assets/a3d5e433-2989-4d99-8f33-918f53e81414" />



with these changes
<img width="800" height="589" alt="Screenshot 2026-02-24 at 20 14 11" src="https://github.com/user-attachments/assets/48aa5a90-9c61-42b1-8ab0-e48a86865193" />
<img width="752" height="198" alt="Screenshot 2026-02-24 at 20 14 46" src="https://github.com/user-attachments/assets/de0056e8-fe32-4c6c-9fa6-2bb1ffb475e6" />
