### PR TITLE
fix: bypass HTTP cache for all URL image widgets on state-change reload

### DIFF
--- a/openHAB/NewImageUITableViewCell.swift
+++ b/openHAB/NewImageUITableViewCell.swift
@@ -218,11 +218,10 @@ class NewImageUITableViewCell: GenericUITableViewCell, NoIconDisplayableCell {
                     throw HTTPClientError.noConfiguration
                 }
                 let client = HTTPClient(connectionConfiguration: config)
-                let cachePolicy: URLRequest.CachePolicy
-                if forceBypassingURLCache || !shouldCache {
-                    cachePolicy = .reloadIgnoringCacheData
+                let cachePolicy: URLRequest.CachePolicy = if forceBypassingURLCache || !shouldCache {
+                    .reloadIgnoringCacheData
                 } else {
-                    cachePolicy = .useProtocolCachePolicy
+                    .useProtocolCachePolicy
                 }
                 let (data, _): (Data, URLResponse) = try await client.doRequest(baseURL: url, timeout: 10.0, type: .data, cacheingPolicy: cachePolicy)
                 await MainActor.run {

--- a/openHAB/NewImageUITableViewCell.swift
+++ b/openHAB/NewImageUITableViewCell.swift
@@ -181,8 +181,7 @@ class NewImageUITableViewCell: GenericUITableViewCell, NoIconDisplayableCell {
             }
         case let .link(url):
             guard let url else { return }
-            let shouldForceBypassCache = forceRefresh && widget?.item?.type == .stringItem
-            loadRemoteImage(withURL: url, forceBypassingURLCache: shouldForceBypassCache)
+            loadRemoteImage(withURL: url, forceBypassingURLCache: forceRefresh)
         default:
             Logger.widgets.debug("Failed to determine widget payload.")
         }


### PR DESCRIPTION
## Summary

- Removes the `widget?.item?.type == .stringItem` guard that was restricting the HTTP cache bypass introduced in #1080 to only `String`-typed items.
- `forceBypassingURLCache` is now passed through unconditionally from `loadImage(forceRefresh:)`, covering both item-backed (`String` item state = URL) and direct-URL (`widget.url`) image widgets.

## Why this is safe

`forceRefresh: true` is only ever supplied by `displayWidget()` — the state-change path. Timer-driven reloads call `loadImage()` without `forceRefresh`, so they continue to respect the configured HTTP cache policy unchanged.

## Test plan

- [ ] Image widget backed by a `String` item whose state is a URL updates immediately when the item state changes in a DSL rule (regression test for #1080)
- [ ] Image widget with a direct sitemap URL (`Image url="..."`) refreshes correctly via its timer without unnecessary extra requests
- [ ] Chart widgets unaffected

Fixes #1082