### PR TITLE
fix: use RFC 3986 relative URL resolution in resolveFullURL

### DIFF
--- a/NotificationService/NotificationService.swift
+++ b/NotificationService/NotificationService.swift
@@ -184,11 +184,12 @@ actor NotificationServiceHandler {
 
     // Helper function to determine full URL
     private func resolveFullURL(from url: String, baseURL: String) -> URL? {
-        if url.starts(with: "/") {
-            URL(string: baseURL)?.appendingPathComponent(url)
-        } else {
-            URL(string: url)
+        if let parsedURL = URL(string: url), parsedURL.scheme != nil {
+            return parsedURL
         }
+
+        guard let parsedBaseURL = URL(string: baseURL) else { return nil }
+        return URL(string: url, relativeTo: parsedBaseURL)?.absoluteURL
     }
 
     func downloadAndAttachItemImage(itemURI: String) async throws -> UNNotificationAttachment? {


### PR DESCRIPTION
## Summary

Fixes the `resolveFullURL(from:baseURL:)` helper in `NotificationService` introduced by #1067.

### Problems with the previous implementation

`appendingPathComponent()` is a file-system path API — it appends to the base URL's *existing path* rather than replacing it:

| base | url | old result | correct |
|---|---|---|---|
| `https://myopenhab.org/oh/v2` | `/rest/items/Image/state` | `…/oh/v2/rest/items/Image/state` ❌ | `…/rest/items/Image/state` ✅ |
| `https://myopenhab.org` | `rest/items/Image/state` | `rest/items/Image/state` (no host, nil download) ❌ | `…/rest/items/Image/state` ✅ |

The second case (relative path without a leading `/`) silently returned `nil`, preventing any attachment download.

### Fix

- **Absolute URLs** (have a scheme): returned unchanged — no behaviour change.
- **Everything else**: resolved via `URL(string:relativeTo:).absoluteURL`, which follows [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986#section-5.2) — absolute-path references resolve against the base origin; relative-path references resolve against the base directory.

## Limitations

If the notification payload contains an absolute URL pointing to a local IP address (e.g. `https://192.168.1.10:8080/…`), the download will still fail when not on the local network. That is a server-side concern.

## Test plan

- [ ] Push a notification with a relative `media-attachment-url` (e.g. `/rest/items/CameraImage/state`) while connected only via openHAB Cloud — image should appear in the notification
- [ ] Push a notification with an absolute `media-attachment-url` while on local network — image still appears (no regression)
- [ ] Push a notification without a `media-attachment-url` — no crash, notification delivered normally

Fixes #1081