### PR TITLE
Fix screensaver layout sizing for large text

### DIFF
--- a/openHAB.xcodeproj/project.pbxproj
+++ b/openHAB.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		652B81042E2193B500648510 /* ScreenSaverSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 652B81032E2193B500648510 /* ScreenSaverSettingsView.swift */; };
 		652B81092E2193DA00648510 /* ScreenSaverManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 652B81062E2193DA00648510 /* ScreenSaverManager.swift */; };
 		652B810A2E2193DA00648510 /* ScreenSaverConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 652B81052E2193DA00648510 /* ScreenSaverConfiguration.swift */; };
+		E1AA00012F5D000100000001 /* ScreenSaverLayoutCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AA00022F5D000100000001 /* ScreenSaverLayoutCalculator.swift */; };
+		E1AA00032F5D000100000001 /* ScreenSaverLayoutCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AA00042F5D000100000001 /* ScreenSaverLayoutCalculatorTests.swift */; };
 		653B54C2285E714900298ECD /* OpenHABViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B54C1285E714900298ECD /* OpenHABViewController.swift */; };
 		65570A7D2476D16A00D524EA /* OpenHABWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65570A7C2476D16A00D524EA /* OpenHABWebViewController.swift */; };
 		6557AF8F2C0241C10094D0C8 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 6557AF8E2C0241C10094D0C8 /* PrivacyInfo.xcprivacy */; };
@@ -342,6 +344,8 @@
 		652B81032E2193B500648510 /* ScreenSaverSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenSaverSettingsView.swift; sourceTree = "<group>"; };
 		652B81052E2193DA00648510 /* ScreenSaverConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenSaverConfiguration.swift; sourceTree = "<group>"; };
 		652B81062E2193DA00648510 /* ScreenSaverManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenSaverManager.swift; sourceTree = "<group>"; };
+		E1AA00022F5D000100000001 /* ScreenSaverLayoutCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenSaverLayoutCalculator.swift; sourceTree = "<group>"; };
+		E1AA00042F5D000100000001 /* ScreenSaverLayoutCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenSaverLayoutCalculatorTests.swift; sourceTree = "<group>"; };
 		653B54C1285E714900298ECD /* OpenHABViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenHABViewController.swift; sourceTree = "<group>"; };
 		653C09D41EAD691A00BA4C4A /* openHAB.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = openHAB.entitlements; sourceTree = "<group>"; };
 		65570A7C2476D16A00D524EA /* OpenHABWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenHABWebViewController.swift; sourceTree = "<group>"; };
@@ -729,6 +733,7 @@
 			isa = PBXGroup;
 			children = (
 				652B81052E2193DA00648510 /* ScreenSaverConfiguration.swift */,
+				E1AA00022F5D000100000001 /* ScreenSaverLayoutCalculator.swift */,
 				652B81062E2193DA00648510 /* ScreenSaverManager.swift */,
 				DA3563D82E5096BE00BC0138 /* ScreenSaverView.swift */,
 			);
@@ -891,6 +896,7 @@
 				DAF231D127BB6EEA00AB916C /* OpenHABSVGTests.swift */,
 				DAF231D327BB6F5C00AB916C /* Ressources */,
 				DABB4CF12F4790AD00111AF3 /* RowLayoutPolicyTests.swift */,
+				E1AA00042F5D000100000001 /* ScreenSaverLayoutCalculatorTests.swift */,
 				DABB4CDD2F4746B100111AF3 /* SitemapRowInputMapperTests.swift */,
 				DABB4CF32F47BC5100111AF3 /* SliderOverrideSyncTests.swift */,
 				2F399AB92F5357E900F72A30 /* InputCommandFormatterTests.swift */,
@@ -1746,6 +1752,7 @@
 				DABB4CF42F47BC5100111AF3 /* SliderOverrideSyncTests.swift in Sources */,
 				DA96415A2F292EE200CEC181 /* BonjourDiscoveryViewModelTests.swift in Sources */,
 				DABB4CF22F4790AD00111AF3 /* RowLayoutPolicyTests.swift in Sources */,
+				E1AA00032F5D000100000001 /* ScreenSaverLayoutCalculatorTests.swift in Sources */,
 				938BF89624EFBC5400E6B52F /* LocalizationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1803,6 +1810,7 @@
 				DFB2623B18830A3600D3244D /* AppDelegate.swift in Sources */,
 				652B81092E2193DA00648510 /* ScreenSaverManager.swift in Sources */,
 				652B810A2E2193DA00648510 /* ScreenSaverConfiguration.swift in Sources */,
+				E1AA00012F5D000100000001 /* ScreenSaverLayoutCalculator.swift in Sources */,
 				2F55E7BD2DEE44A800EC8350 /* ClientCertificatesView.swift in Sources */,
 				DA6B2EF72C8B92E800DF77CF /* SelectionView.swift in Sources */,
 				DA64ACA82DBEAD8300294F60 /* SitemapPageView.swift in Sources */,

--- a/openHAB/ScreenSaver/ScreenSaverLayoutCalculator.swift
+++ b/openHAB/ScreenSaver/ScreenSaverLayoutCalculator.swift
@@ -49,32 +49,23 @@ enum ScreenSaverLayoutCalculator {
         let baseTimeFontSize = max(shortSide * configuration.timeFontSizeRatio, 48)
         let baseDateFontSize = baseTimeFontSize * configuration.dateFontRelativeSize
         let maximumWidth = max(containerSize.width - edgeMargin * 2, 1)
-
-        let baseFonts = fonts(
-            timeFontSize: baseTimeFontSize,
-            dateFontSize: baseDateFontSize,
-            fontName: fontName
-        )
-
-        let baseWidth = measuredWidth(
+        let fittedSizes = fittedFontSizes(
+            maximumWidth: maximumWidth,
+            baseTimeFontSize: baseTimeFontSize,
+            baseDateFontSize: baseDateFontSize,
             dateText: dateText,
             timeText: timeText,
-            dateFont: baseFonts.date,
-            timeFont: baseFonts.time
+            fontName: fontName
         )
-        let scale = baseWidth > maximumWidth ? maximumWidth / baseWidth : 1
-
-        let fittedTimeFontSize = baseTimeFontSize * scale
-        let fittedDateFontSize = baseDateFontSize * scale
         let fittedFonts = fonts(
-            timeFontSize: fittedTimeFontSize,
-            dateFontSize: fittedDateFontSize,
+            timeFontSize: fittedSizes.time,
+            dateFontSize: fittedSizes.date,
             fontName: fontName
         )
 
         return ScreenSaverTextLayout(
-            timeFontSize: fittedTimeFontSize,
-            dateFontSize: fittedDateFontSize,
+            timeFontSize: fittedSizes.time,
+            dateFontSize: fittedSizes.date,
             contentSize: measuredSize(
                 dateText: dateText,
                 timeText: timeText,
@@ -82,6 +73,42 @@ enum ScreenSaverLayoutCalculator {
                 timeFont: fittedFonts.time
             )
         )
+    }
+
+    private static func fittedFontSizes(
+        maximumWidth: CGFloat,
+        baseTimeFontSize: CGFloat,
+        baseDateFontSize: CGFloat,
+        dateText: String?,
+        timeText: String?,
+        fontName: String?
+    ) -> (time: CGFloat, date: CGFloat) {
+        var timeFontSize = baseTimeFontSize
+        var dateFontSize = baseDateFontSize
+
+        for _ in 0 ..< 3 {
+            let currentFonts = fonts(
+                timeFontSize: timeFontSize,
+                dateFontSize: dateFontSize,
+                fontName: fontName
+            )
+            let currentWidth = measuredWidth(
+                dateText: dateText,
+                timeText: timeText,
+                dateFont: currentFonts.date,
+                timeFont: currentFonts.time
+            )
+
+            guard currentWidth > maximumWidth else {
+                break
+            }
+
+            let correction = maximumWidth / currentWidth
+            timeFontSize *= correction
+            dateFontSize *= correction
+        }
+
+        return (timeFontSize, dateFontSize)
     }
 
     private static func fonts(

--- a/openHAB/ScreenSaver/ScreenSaverLayoutCalculator.swift
+++ b/openHAB/ScreenSaver/ScreenSaverLayoutCalculator.swift
@@ -1,0 +1,143 @@
+// Copyright (c) 2010-2026 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+import CoreGraphics
+import Foundation
+import UIKit
+
+struct ScreenSaverTextLayout {
+    let timeFontSize: CGFloat
+    let dateFontSize: CGFloat
+    let contentSize: CGSize
+
+    func position(in containerSize: CGSize, anchor: CGPoint, edgeMargin: CGFloat) -> CGPoint {
+        let availableWidth = max(containerSize.width - contentSize.width - edgeMargin * 2, 0)
+        let availableHeight = max(containerSize.height - contentSize.height - edgeMargin * 2, 0)
+
+        let clampedAnchorX = min(max(anchor.x, 0), 1)
+        let clampedAnchorY = min(max(anchor.y, 0), 1)
+
+        let x = edgeMargin + contentSize.width / 2 + availableWidth * clampedAnchorX
+        let y = edgeMargin + contentSize.height / 2 + availableHeight * clampedAnchorY
+
+        return CGPoint(
+            x: min(max(x, contentSize.width / 2), max(containerSize.width - contentSize.width / 2, contentSize.width / 2)),
+            y: min(max(y, contentSize.height / 2), max(containerSize.height - contentSize.height / 2, contentSize.height / 2))
+        )
+    }
+}
+
+enum ScreenSaverLayoutCalculator {
+    static let edgeMargin: CGFloat = 20
+
+    static func layout(
+        containerSize: CGSize,
+        configuration: ScreenSaverConfiguration,
+        dateText: String?,
+        timeText: String?,
+        fontName: String?
+    ) -> ScreenSaverTextLayout {
+        let shortSide = min(containerSize.width, containerSize.height)
+        let baseTimeFontSize = max(shortSide * configuration.timeFontSizeRatio, 48)
+        let baseDateFontSize = baseTimeFontSize * configuration.dateFontRelativeSize
+        let maximumWidth = max(containerSize.width - edgeMargin * 2, 1)
+
+        let baseFonts = fonts(
+            timeFontSize: baseTimeFontSize,
+            dateFontSize: baseDateFontSize,
+            fontName: fontName
+        )
+
+        let baseWidth = measuredWidth(
+            dateText: dateText,
+            timeText: timeText,
+            dateFont: baseFonts.date,
+            timeFont: baseFonts.time
+        )
+        let scale = baseWidth > maximumWidth ? maximumWidth / baseWidth : 1
+
+        let fittedTimeFontSize = baseTimeFontSize * scale
+        let fittedDateFontSize = baseDateFontSize * scale
+        let fittedFonts = fonts(
+            timeFontSize: fittedTimeFontSize,
+            dateFontSize: fittedDateFontSize,
+            fontName: fontName
+        )
+
+        return ScreenSaverTextLayout(
+            timeFontSize: fittedTimeFontSize,
+            dateFontSize: fittedDateFontSize,
+            contentSize: measuredSize(
+                dateText: dateText,
+                timeText: timeText,
+                dateFont: fittedFonts.date,
+                timeFont: fittedFonts.time
+            )
+        )
+    }
+
+    private static func fonts(
+        timeFontSize: CGFloat,
+        dateFontSize: CGFloat,
+        fontName: String?
+    ) -> (time: UIFont, date: UIFont) {
+        if let fontName,
+           let timeFont = UIFont(name: fontName, size: timeFontSize),
+           let dateFont = UIFont(name: fontName, size: dateFontSize)
+        {
+            return (timeFont, dateFont)
+        }
+
+        return (
+            UIFont.monospacedDigitSystemFont(ofSize: timeFontSize, weight: .thin),
+            UIFont.systemFont(ofSize: dateFontSize, weight: .regular)
+        )
+    }
+
+    private static func measuredWidth(
+        dateText: String?,
+        timeText: String?,
+        dateFont: UIFont,
+        timeFont: UIFont
+    ) -> CGFloat {
+        max(
+            lineWidth(dateText, font: dateFont),
+            lineWidth(timeText, font: timeFont)
+        )
+    }
+
+    private static func measuredSize(
+        dateText: String?,
+        timeText: String?,
+        dateFont: UIFont,
+        timeFont: UIFont
+    ) -> CGSize {
+        let width = measuredWidth(
+            dateText: dateText,
+            timeText: timeText,
+            dateFont: dateFont,
+            timeFont: timeFont
+        )
+        let height =
+            (dateText == nil ? 0 : ceil(dateFont.lineHeight)) +
+            (timeText == nil ? 0 : ceil(timeFont.lineHeight))
+
+        return CGSize(width: ceil(width), height: ceil(height))
+    }
+
+    private static func lineWidth(_ text: String?, font: UIFont) -> CGFloat {
+        guard let text, !text.isEmpty else {
+            return 0
+        }
+
+        return ceil((text as NSString).size(withAttributes: [.font: font]).width)
+    }
+}

--- a/openHAB/ScreenSaver/ScreenSaverView.swift
+++ b/openHAB/ScreenSaver/ScreenSaverView.swift
@@ -15,10 +15,6 @@ import os.log
 import SwiftUI
 
 struct ScreenSaverView: View {
-    // Constants for text dimension estimation
-    private static let timeTextWidthMultiplier: CGFloat = 4.0
-    private static let dateTextHeightMultiplier: CGFloat = 1.4
-
     private static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
@@ -56,8 +52,7 @@ struct ScreenSaverView: View {
 
     let configuration: ScreenSaverConfiguration
 
-    @State private var currentPosition: CGPoint = .zero
-    @State private var screenSize: CGSize = .zero
+    @State private var currentAnchor = CGPoint(x: 0.5, y: 0.5)
     @State private var fadeOpacity = 1.0
     @State private var movementTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
     @State private var isTimerActive = false
@@ -73,23 +68,30 @@ struct ScreenSaverView: View {
                     }
 
                 TimelineView(.periodic(from: .now, by: 1.0)) { context in
+                    let fontName = validatedFontName()
+                    let layout = currentLayout(for: context.date, size: geometry.size, fontName: fontName)
+
                     VStack(spacing: 0) {
                         if configuration.showsDate {
                             Text(dateString(for: context.date))
-                                .font(dateFont(for: geometry.size))
+                                .font(dateFont(size: layout.dateFontSize, fontName: fontName))
                                 .monospacedDigit()
                                 .foregroundStyle(.white.opacity(0.85 * alphaFactor))
                         }
 
                         if configuration.showsTime {
                             Text(timeString(for: context.date))
-                                .font(timeFont(for: geometry.size))
+                                .font(timeFont(size: layout.timeFontSize, fontName: fontName))
                                 .monospacedDigit()
                                 .foregroundStyle(.white.opacity(alphaFactor))
                         }
                     }
                     .opacity(fadeOpacity)
-                    .position(currentPosition)
+                    .position(layout.position(
+                        in: geometry.size,
+                        anchor: currentAnchor,
+                        edgeMargin: ScreenSaverLayoutCalculator.edgeMargin
+                    ))
                 }
             }
             .onReceive(movementTimer) { _ in
@@ -106,23 +108,21 @@ struct ScreenSaverView: View {
                     try? await Task.sleep(nanoseconds: UInt64(half * 1_000_000_000))
                     guard !Task.isCancelled else { return }
 
-                    currentPosition = calculateRandomPosition(for: screenSize)
+                    currentAnchor = randomAnchor()
                     withAnimation(.easeInOut(duration: half)) {
                         fadeOpacity = 1.0
                     }
                 }
             }
             .onAppear {
-                screenSize = geometry.size
-                currentPosition = calculateRandomPosition(for: geometry.size)
+                currentAnchor = randomAnchor()
                 startMovementTimer()
             }
             .onDisappear {
                 stopMovementTimer()
             }
-            .onChange(of: geometry.size) { newSize in
-                screenSize = newSize
-                currentPosition = calculateRandomPosition(for: newSize)
+            .onChange(of: geometry.size) { _ in
+                currentAnchor = randomAnchor()
             }
         }
     }
@@ -148,31 +148,19 @@ struct ScreenSaverView: View {
         Self.dateFormatter.string(from: date)
     }
 
-    private func timeFont(for size: CGSize) -> Font {
-        let shortSide = min(size.width, size.height)
-        let fontSize = max(shortSide * configuration.timeFontSizeRatio, 48)
-
-        if let fontName = configuration.fontName {
-            if isFontAvailable(fontName) {
-                return .custom(fontName, size: fontSize)
-            } else {
-                Logger.screenSaver.warning("Custom font '\(fontName)' not found. Falling back to system font.")
-                return .system(size: fontSize, weight: .thin)
-            }
+    private func timeFont(size: CGFloat, fontName: String?) -> Font {
+        if let fontName {
+            .custom(fontName, size: size)
         } else {
-            return .system(size: fontSize, weight: .thin)
+            .system(size: size, weight: .thin)
         }
     }
 
-    private func dateFont(for size: CGSize) -> Font {
-        let shortSide = min(size.width, size.height)
-        let timeFontSize = max(shortSide * configuration.timeFontSizeRatio, 48)
-        let dateFontSize = timeFontSize * configuration.dateFontRelativeSize
-
-        if let fontName = configuration.fontName {
-            return .custom(fontName, size: dateFontSize)
+    private func dateFont(size: CGFloat, fontName: String?) -> Font {
+        if let fontName {
+            .custom(fontName, size: size)
         } else {
-            return .system(size: dateFontSize, weight: .regular)
+            .system(size: size, weight: .regular)
         }
     }
 
@@ -189,44 +177,40 @@ struct ScreenSaverView: View {
         movementTimer.upstream.connect().cancel()
     }
 
-    private func calculateRandomPosition(for size: CGSize) -> CGPoint {
-        guard size.width > 0, size.height > 0 else {
-            return CGPoint(x: size.width / 2, y: size.height / 2)
+    private func currentLayout(for date: Date, size: CGSize, fontName: String?) -> ScreenSaverTextLayout {
+        ScreenSaverLayoutCalculator.layout(
+            containerSize: size,
+            configuration: configuration,
+            dateText: configuration.showsDate ? dateString(for: date) : nil,
+            timeText: configuration.showsTime ? timeString(for: date) : nil,
+            fontName: fontName
+        )
+    }
+
+    private func randomAnchor() -> CGPoint {
+        CGPoint(x: CGFloat.random(in: 0 ... 1), y: CGFloat.random(in: 0 ... 1))
+    }
+
+    private func validatedFontName() -> String? {
+        guard let fontName = configuration.fontName else {
+            return nil
         }
 
-        let edgeMargin: CGFloat = 20
-
-        // Estimate label size (this is approximate since we can't measure exactly in SwiftUI)
-        let shortSide = min(size.width, size.height)
-        let timeFontSize = max(shortSide * configuration.timeFontSizeRatio, 48)
-        let estimatedWidth = timeFontSize * Self.timeTextWidthMultiplier
-        let estimatedHeight = timeFontSize * (configuration.showsDate ? Self.dateTextHeightMultiplier : 1.0)
-
-        let availableWidth = size.width - estimatedWidth - edgeMargin * 2
-        let availableHeight = size.height - estimatedHeight - edgeMargin * 2
-
-        if availableWidth > 0, availableHeight > 0 {
-            let randomX = edgeMargin + estimatedWidth / 2 + CGFloat.random(in: 0 ... availableWidth)
-            let randomY = edgeMargin + estimatedHeight / 2 + CGFloat.random(in: 0 ... availableHeight)
-            return CGPoint(x: randomX, y: randomY)
-        } else {
-            // Fallback for small screens - use full screen area with minimum margins
-            let minMargin: CGFloat = 10
-            let safeWidth = max(size.width - minMargin * 2, size.width * 0.1)
-            let safeHeight = max(size.height - minMargin * 2, size.height * 0.1)
-            let fallbackX = minMargin + CGFloat.random(in: 0 ... safeWidth)
-            let fallbackY = minMargin + CGFloat.random(in: 0 ... safeHeight)
-            return CGPoint(x: fallbackX, y: fallbackY)
+        guard isFontAvailable(fontName) else {
+            Logger.screenSaver.warning("Custom font '\(fontName)' not found. Falling back to system font.")
+            return nil
         }
+
+        return fontName
     }
 
     func isFontAvailable(_ fontName: String) -> Bool {
         #if os(iOS) || os(tvOS) || os(watchOS)
-        return UIFont(name: fontName, size: 12) != nil
+            return UIFont(name: fontName, size: 12) != nil
         #elseif os(macOS)
-        return NSFont(name: fontName, size: 12) != nil
+            return NSFont(name: fontName, size: 12) != nil
         #else
-        return false
+            return false
         #endif
     }
 }

--- a/openHABTestsSwift/ScreenSaverLayoutCalculatorTests.swift
+++ b/openHABTestsSwift/ScreenSaverLayoutCalculatorTests.swift
@@ -17,6 +17,8 @@ import Testing
 struct ScreenSaverLayoutCalculatorTests {
     @Test
     func oversizedTimeTextScalesDownToFitHorizontalMargins() {
+        let containerSize = CGSize(width: 320, height: 568)
+        let maxWidth = containerSize.width - ScreenSaverLayoutCalculator.edgeMargin * 2
         let configuration = ScreenSaverConfiguration(
             showsTime: true,
             showsDate: false,
@@ -24,14 +26,14 @@ struct ScreenSaverLayoutCalculatorTests {
         )
 
         let layout = ScreenSaverLayoutCalculator.layout(
-            containerSize: CGSize(width: 320, height: 568),
+            containerSize: containerSize,
             configuration: configuration,
             dateText: nil,
-            timeText: "11:11:11 PMMMMM",
+            timeText: "11:11:11 PMMMMMMMMMMMMMMMMMMMMM",
             fontName: nil
         )
 
-        #expect(layout.contentSize.width <= 280)
+        #expect(layout.contentSize.width <= maxWidth)
         #expect(layout.timeFontSize < 112)
     }
 

--- a/openHABTestsSwift/ScreenSaverLayoutCalculatorTests.swift
+++ b/openHABTestsSwift/ScreenSaverLayoutCalculatorTests.swift
@@ -1,0 +1,84 @@
+// Copyright (c) 2010-2026 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+import CoreGraphics
+@testable import openHAB
+import Testing
+
+@Suite
+struct ScreenSaverLayoutCalculatorTests {
+    @Test
+    func oversizedTimeTextScalesDownToFitHorizontalMargins() {
+        let configuration = ScreenSaverConfiguration(
+            showsTime: true,
+            showsDate: false,
+            timeFontSizeRatio: 0.35
+        )
+
+        let layout = ScreenSaverLayoutCalculator.layout(
+            containerSize: CGSize(width: 320, height: 568),
+            configuration: configuration,
+            dateText: nil,
+            timeText: "11:11:11 PMMMMM",
+            fontName: nil
+        )
+
+        #expect(layout.contentSize.width <= 280)
+        #expect(layout.timeFontSize < 112)
+    }
+
+    @Test
+    func anchorAtTrailingEdgeKeepsContentInsideMargins() {
+        let configuration = ScreenSaverConfiguration(
+            showsTime: true,
+            showsDate: true,
+            timeFontSizeRatio: 0.2,
+            dateFontRelativeSize: 0.4
+        )
+
+        let layout = ScreenSaverLayoutCalculator.layout(
+            containerSize: CGSize(width: 390, height: 844),
+            configuration: configuration,
+            dateText: "Mar 10, 2026",
+            timeText: "11:11 PM",
+            fontName: nil
+        )
+        let position = layout.position(
+            in: CGSize(width: 390, height: 844),
+            anchor: CGPoint(x: 1, y: 1),
+            edgeMargin: ScreenSaverLayoutCalculator.edgeMargin
+        )
+
+        #expect(position.x + layout.contentSize.width / 2 <= 370.5)
+        #expect(position.y + layout.contentSize.height / 2 <= 824.5)
+    }
+
+    @Test
+    func fittingIsStableWhenContentAlreadyFits() {
+        let configuration = ScreenSaverConfiguration(
+            showsTime: true,
+            showsDate: true,
+            timeFontSizeRatio: 0.2,
+            dateFontRelativeSize: 0.4
+        )
+
+        let layout = ScreenSaverLayoutCalculator.layout(
+            containerSize: CGSize(width: 1024, height: 768),
+            configuration: configuration,
+            dateText: "Mar 10, 2026",
+            timeText: "11:11 PM",
+            fontName: nil
+        )
+
+        #expect(abs(layout.timeFontSize - 153.6) < 0.001)
+        #expect(abs(layout.dateFontSize - 61.44) < 0.001)
+    }
+}


### PR DESCRIPTION
## Summary
- replace guessed screensaver text bounds with measured date/time layout sizing
- scale oversized screensaver content down to keep it within horizontal margins
- add focused Swift Testing coverage for layout fitting and edge clamping

## Testing
- `swiftformat --lint openHAB/ScreenSaver/ScreenSaverLayoutCalculator.swift openHAB/ScreenSaver/ScreenSaverView.swift openHABTestsSwift/ScreenSaverLayoutCalculatorTests.swift`
- `xcodebuild test -workspace openHAB.xcworkspace -scheme openHABTestsSwift -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:openHABTestsSwift/ScreenSaverLayoutCalculatorTests` *(build completed, but test execution could not finish because CoreSimulatorService was unavailable in the local environment)*