### PR TITLE
Fix empty string commands and switch sendItemCommand to JSON payload

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/GeneratedSources/openapi/Types.swift
+++ b/OpenHABCore/Sources/OpenHABCore/GeneratedSources/openapi/Types.swift
@@ -8004,8 +8004,23 @@ public enum Operations {
             @frozen public enum Body: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/items/{itemname}/POST/requestBody/content/text\/plain`.
                 case plainText(OpenAPIRuntime.HTTPBody)
+                /// - Remark: Generated from `#/paths/items/{itemname}/POST/requestBody/json`.
+                public struct jsonPayload: Codable, Hashable, Sendable {
+                    /// - Remark: Generated from `#/paths/items/{itemname}/POST/requestBody/json/value`.
+                    public var value: Swift.String
+                    /// Creates a new `jsonPayload`.
+                    ///
+                    /// - Parameters:
+                    ///   - value:
+                    public init(value: Swift.String) {
+                        self.value = value
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case value
+                    }
+                }
                 /// - Remark: Generated from `#/paths/items/{itemname}/POST/requestBody/content/application\/json`.
-                case json(Swift.String)
+                case json(Operations.sendItemCommand.Input.Body.jsonPayload)
             }
             public var body: Operations.sendItemCommand.Input.Body
             /// Creates a new `Input`.

--- a/OpenHABCore/Sources/OpenHABCore/Util/OpenAPIService.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/OpenAPIService.swift
@@ -360,7 +360,8 @@ public extension OpenAPIService {
 
     func sendItemCommand(itemname: String, command: String, sourcePrefix: String? = nil, deviceId: String? = nil) async throws {
         let path = Operations.sendItemCommand.Input.Path(itemname: itemname)
-        let body = Operations.sendItemCommand.Input.Body.plainText(.init(command))
+        let payload = Operations.sendItemCommand.Input.Body.jsonPayload(value: command)
+        let body = Operations.sendItemCommand.Input.Body.json(payload)
         let query = Operations.sendItemCommand.Input.Query(source: buildSource(sourcePrefix: sourcePrefix, deviceId: deviceId))
         let response = try await client.sendItemCommand(path: path, query: query, body: body)
         _ = try response.ok

--- a/OpenHABCore/Sources/OpenHABCore/Util/WidgetCommandDispatcher.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/WidgetCommandDispatcher.swift
@@ -24,7 +24,7 @@ public final class WidgetCommandDispatcher {
                      phase: WidgetCommandPhase = .change,
                      key: String? = nil,
                      fallbackItem: OpenHABItem? = nil) {
-        guard let command, !command.isEmpty else { return }
+        guard let command else { return }
 
         switch policy {
         case .immediate:
@@ -57,7 +57,7 @@ public final class WidgetCommandDispatcher {
                      phase: WidgetCommandPhase = .change,
                      key: String? = nil,
                      execute: @escaping @MainActor (_ itemname: String, _ command: String) -> Void) {
-        guard let command, !command.isEmpty, !itemname.isEmpty else { return }
+        guard let command, !itemname.isEmpty else { return }
 
         switch policy {
         case .immediate:
@@ -90,7 +90,7 @@ public final class WidgetCommandDispatcher {
                      phase: WidgetCommandPhase = .change,
                      key: String? = nil,
                      execute: @escaping @MainActor (_ itemname: String, _ command: String) -> Void) {
-        guard let command, !command.isEmpty, let item else { return }
+        guard let command, let item else { return }
 
         switch policy {
         case .immediate:
@@ -120,7 +120,7 @@ public final class WidgetCommandDispatcher {
     public func sendPress(_ command: String?,
                           for widget: OpenHABWidget,
                           fallbackItem: OpenHABItem? = nil) {
-        guard let command, !command.isEmpty else { return }
+        guard let command else { return }
         dispatch(command: command, for: widget, fallbackItem: fallbackItem)
     }
 
@@ -128,7 +128,7 @@ public final class WidgetCommandDispatcher {
     public func sendRelease(_ command: String?,
                             for widget: OpenHABWidget,
                             fallbackItem: OpenHABItem? = nil) {
-        guard let command, !command.isEmpty else { return }
+        guard let command else { return }
         dispatch(command: command, for: widget, fallbackItem: fallbackItem)
     }
 

--- a/OpenHABCore/Sources/OpenHABCore/openapi/openapi.json
+++ b/OpenHABCore/Sources/OpenHABCore/openapi/openapi.json
@@ -3000,11 +3000,13 @@
             },
             "application/json": {
               "schema": {
-                "type": "string",
-                "example": {
-                  "value": "ON",
-                  "source": "org.openhab.ios"
-                }
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": ["value"]
               }
             }
           },

--- a/OpenHABCore/Tests/OpenHABCoreTests/OpenAPIServiceSendItemCommandTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/OpenAPIServiceSendItemCommandTests.swift
@@ -1,0 +1,53 @@
+// Copyright (c) 2010-2026 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+import Foundation
+import HTTPTypes
+import OpenAPIRuntime
+import OpenHABCore
+import Testing
+
+@Suite
+struct OpenAPIServiceSendItemCommandTests {
+    @Test("sendItemCommand uses application/json with object payload")
+    func sendItemCommandUsesJSONPayload() async throws {
+        let transport = TestClientTransport { request, body, baseURL, operationID in
+            #expect(operationID == "sendItemCommand")
+            #expect(request.method == .post)
+            #expect(request.path == "/items/MyItem")
+            #expect(baseURL.absoluteString == "/rest")
+            #expect(request.headerFields[.contentType] == "application/json; charset=utf-8")
+            #expect(try await encodedBody(from: body) == #"{"value":"ON"}"#)
+
+            return (try HTTPResponse(status: .ok), nil)
+        }
+        let client = try Client(
+            serverURL: URL(validatingOpenAPIServerURL: "/rest"),
+            configuration: .init(multipartBoundaryGenerator: .constant),
+            transport: transport
+        )
+        let service = OpenAPIService(client: client)
+
+        try await service.sendItemCommand(itemname: "MyItem", command: "ON")
+    }
+
+    private func encodedBody(from body: HTTPBody?) async throws -> String {
+        guard let body else {
+            throw TestError.unexpectedMissingRequestBody
+        }
+
+        var bytes = [UInt8]()
+        for try await chunk in body {
+            bytes.append(contentsOf: chunk)
+        }
+        return String(decoding: bytes, as: UTF8.self)
+    }
+}

--- a/OpenHABCore/Tests/OpenHABCoreTests/OpenAPIServiceSendItemCommandTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/OpenAPIServiceSendItemCommandTests.swift
@@ -30,7 +30,7 @@ struct OpenAPIServiceSendItemCommandTests {
             let json = try JSONDecoder().decode([String: String].self, from: Data(bodyString.utf8))
             #expect(json["value"] == "ON")
 
-            return (try HTTPResponse(status: .ok), nil)
+            return (HTTPResponse(status: .ok), nil)
         }
         let client = try Client(
             serverURL: URL(validatingOpenAPIServerURL: "/rest"),

--- a/OpenHABCore/Tests/OpenHABCoreTests/OpenAPIServiceSendItemCommandTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/OpenAPIServiceSendItemCommandTests.swift
@@ -22,10 +22,13 @@ struct OpenAPIServiceSendItemCommandTests {
         let transport = TestClientTransport { request, body, baseURL, operationID in
             #expect(operationID == "sendItemCommand")
             #expect(request.method == .post)
-            #expect(request.path == "/items/MyItem")
+            #expect(URLComponents(string: request.path ?? "")?.path == "/items/MyItem")
             #expect(baseURL.absoluteString == "/rest")
             #expect(request.headerFields[.contentType] == "application/json; charset=utf-8")
-            #expect(try await encodedBody(from: body) == #"{"value":"ON"}"#)
+
+            let bodyString = try await self.encodedBody(from: body)
+            let json = try JSONDecoder().decode([String: String].self, from: Data(bodyString.utf8))
+            #expect(json["value"] == "ON")
 
             return (try HTTPResponse(status: .ok), nil)
         }

--- a/OpenHABCore/Tests/OpenHABCoreTests/WidgetCommandDispatcherTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/WidgetCommandDispatcherTests.swift
@@ -1,0 +1,42 @@
+// Copyright (c) 2010-2026 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+import OpenHABCore
+import Testing
+
+@Suite
+@MainActor
+struct WidgetCommandDispatcherTests {
+    @Test("Empty string command is dispatched for item name")
+    func emptyStringCommandIsDispatchedForItemName() {
+        let dispatcher = WidgetCommandDispatcher()
+        var received: (itemname: String, command: String)?
+
+        dispatcher.send("", for: "MyItem", policy: .immediate) { itemname, command in
+            received = (itemname, command)
+        }
+
+        #expect(received?.itemname == "MyItem")
+        #expect(received?.command == "")
+    }
+
+    @Test("Nil command is still ignored for item name")
+    func nilCommandIsIgnoredForItemName() {
+        let dispatcher = WidgetCommandDispatcher()
+        var callCount = 0
+
+        dispatcher.send(nil, for: "MyItem", policy: .immediate) { _, _ in
+            callCount += 1
+        }
+
+        #expect(callCount == 0)
+    }
+}

--- a/openHAB/SwiftUI/Rows/TextInputRowView.swift
+++ b/openHAB/SwiftUI/Rows/TextInputRowView.swift
@@ -23,8 +23,8 @@ enum InputCommandFormatter {
 
     static func command(from rawText: String, hint: OpenHABWidget.InputHint?) -> String? {
         let trimmed = rawText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
         guard hint == .number else { return trimmed }
+        guard !trimmed.isEmpty else { return nil }
         return normalizedNumberCommand(from: trimmed)
     }
 

--- a/openHABTestsSwift/InputCommandFormatterTests.swift
+++ b/openHABTestsSwift/InputCommandFormatterTests.swift
@@ -228,8 +228,18 @@ struct InputCommandFormatterTests {
     }
 
     @Test
+    func commandFromEmptyStringForTextReturnsEmptyString() {
+        #expect(InputCommandFormatter.command(from: "", hint: nil) == "")
+    }
+
+    @Test
     func commandFromWhitespaceReturnsNil() {
         #expect(InputCommandFormatter.command(from: "   ", hint: .number) == nil)
+    }
+
+    @Test
+    func commandFromWhitespaceForTextReturnsEmptyString() {
+        #expect(InputCommandFormatter.command(from: "   ", hint: nil) == "")
     }
 
     @Test


### PR DESCRIPTION
Fix for empty input https://github.com/openhab/openhab-ios/pull/892#issuecomment-3992808822 

Requires another manual patch of openHAB's openapi spec. 

## Summary

- **Allow clearing text items**: `InputCommandFormatter.command()` now returns `""` for empty/whitespace text input (non-number hint) instead of `nil`, so users can submit an empty string to clear a text item's state.
- **Dispatch empty commands**: Removed `!command.isEmpty` guards in `WidgetCommandDispatcher` — empty strings are now valid commands and are no longer silently dropped.
- **Fix OpenAPI schema**: The `sendItemCommand` endpoint's `application/json` body was incorrectly typed as `string`; corrected to `object` with a required `value` field, matching the actual server contract. `Types.swift` and `OpenAPIService` updated accordingly (uses `{"value":"..."}` JSON body instead of plain text).

## Test plan

- [ ] New `OpenAPIServiceSendItemCommandTests` verifies `sendItemCommand` sends `Content-Type: application/json` with body `{"value":"ON"}`.
- [ ] New `WidgetCommandDispatcherTests` verifies empty string commands are dispatched and `nil` commands are still ignored.
- [ ] New `InputCommandFormatterTests` cases verify empty/whitespace text input returns `""`, and number hint still returns `nil` for empty input.
- [ ] Run the full test suite and confirm no regressions.
- [ ] Manually test clearing a text item in the app by submitting an empty text field.