### PR TITLE
Fix Firebase/Crashlytics silenced by deferred initialization

### DIFF
--- a/openHAB/AppDelegate.swift
+++ b/openHAB/AppDelegate.swift
@@ -61,6 +61,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         Preferences.migratePreferences()
 
+        // Firebase must be configured before the storyboard loads its root view controller,
+        // because OpenHABRootViewController.viewDidLoad calls Crashlytics before the deferred
+        // task would have had a chance to run. Calling Crashlytics before FirebaseApp.configure()
+        // silences crash detection for the entire session.
+        setupFirebase()
+
         UNUserNotificationCenter.current().delegate = notificationDelegate
 
         Logger.appDelegate.info("didFinishLaunchingWithOptions ended")
@@ -78,8 +84,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     /// Setup that can be deferred until after the UI appears
     @MainActor
     private func performDeferredSetup() {
-        setupFirebase()
-
         registerForPushNotifications()
         Logger.appDelegate.info("uniq id: \(UIDevice.current.identifierForVendor?.uuidString ?? "")")
         Logger.appDelegate.info("device name: \(UIDevice.current.name)")


### PR DESCRIPTION
## Summary

- `setupFirebase()` was moved into a 100 ms-deferred `Task` in 7afbc8f8, but `OpenHABRootViewController.viewDidLoad` calls `Crashlytics.crashlytics()` synchronously during storyboard load — before that task ever runs
- Accessing Crashlytics before `FirebaseApp.configure()` causes the SDK to return a non-functional stub: `didCrashDuringPreviousExecution()` always returns `false`, the opt-in dialog never shows, `sendUnsentReports()` is never called, and crash-handler signal registration is skipped for the whole session
- This is the root cause of crash data disappearing from Firebase starting with the builds that shipped 7afbc8f8

## Fix

Move `setupFirebase()` back into `didFinishLaunchingWithOptions`, immediately before the deferred `Task`. All other non-essential setup (push notifications, audio session, watch connectivity, screensaver) remains deferred. Firebase configuration takes microseconds and does not measurably affect launch time.

## Test plan

- [ ] Launch app cold — verify no crash on startup
- [ ] Force a test crash (e.g. `fatalError()` behind a debug flag), relaunch — confirm opt-in dialog appears and crash shows up in Firebase Crashlytics console
- [ ] Confirm `sendCrashReports` preference toggle still enables/disables Crashlytics collection correctly