### PR TITLE
Allow for two lines for Selection Row value

### DIFF
--- a/openHAB/UI/SwiftUI/Rows/SelectionRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/SelectionRowView.swift
@@ -103,9 +103,8 @@ private struct SelectionRowContent: View {
                             Text(valueText)
                                 .ohTextToken(.rowValue)
                                 .foregroundStyle(input.valueColor.isEmpty ? .secondary : Color(fromString: input.valueColor))
-                                .lineLimit(1)
+                                .lineLimit(2)
                                 .minimumScaleFactor(0.85)
-                                .fixedSize(horizontal: true, vertical: false)
                                 .layoutPriority(1)
                         }
 

--- a/openHABWatch/Views/Rows/SelectionRow.swift
+++ b/openHABWatch/Views/Rows/SelectionRow.swift
@@ -118,6 +118,7 @@ struct SelectionRow: View {
                     if let valueText = selectedValueText {
                         Text(valueText)
                             .foregroundStyle(widget.valuecolor.isEmpty ? .secondary : Color(fromString: widget.valuecolor))
+                            .lineLimit(2)
                             .watchTextStyle(.secondary)
                     }
                     Image(systemSymbol: .chevronUpChevronDown)


### PR DESCRIPTION
Fix Selection row values by allowing two lines
iOS
<img width="412" height="130" alt="Screenshot 2026-03-30 at 00 24 16" src="https://github.com/user-attachments/assets/5b2975e0-b317-4ac7-8237-a469820705c4" />
to
<img width="416" height="161" alt="Screenshot 2026-03-30 at 00 34 43" src="https://github.com/user-attachments/assets/d72cf91a-a36b-49eb-aec3-e4f2fa413383" />

watchOS
<img width="352" height="94" alt="Simulator Screenshot - MyAppleWatch9 - 2026-03-29 at 20 18 15" src="https://github.com/user-attachments/assets/ecc58a48-fa9d-4a9c-9866-680697e7a318" />
to
<img width="352" height="93" alt="Simulator Screenshot - MyAppleWatch9 - 2026-03-29 at 20 10 30" src="https://github.com/user-attachments/assets/e3110489-3a8b-419e-8cbe-ef718446cb1b" />
