### PR TITLE
fix: rename WatchLabelText labelColor parameter (review of #1120)

### DIFF
--- a/openHABWatch/Views/Rows/GenericRow.swift
+++ b/openHABWatch/Views/Rows/GenericRow.swift
@@ -20,7 +20,7 @@ struct GenericRow: View {
     var body: some View {
         HStack {
             WatchIconView(model: widget.iconRenderModel(), settings: settings)
-            WatchLabelText(text: widget.labelText ?? widget.label)
+            WatchLabelText(text: widget.labelText ?? widget.label, valueColor: widget.labelcolor)
             Spacer()
             DetailTextLabelView(text: widget.labelValue, valueColor: widget.valuecolor)
             widget.makeView(settings: settings)

--- a/openHABWatch/Views/Rows/GenericRow.swift
+++ b/openHABWatch/Views/Rows/GenericRow.swift
@@ -20,7 +20,7 @@ struct GenericRow: View {
     var body: some View {
         HStack {
             WatchIconView(model: widget.iconRenderModel(), settings: settings)
-            WatchLabelText(text: widget.labelText ?? widget.label, valueColor: widget.labelcolor)
+            WatchLabelText(text: widget.labelText ?? widget.label, labelColor: widget.labelcolor)
             Spacer()
             DetailTextLabelView(text: widget.labelValue, valueColor: widget.valuecolor)
             widget.makeView(settings: settings)

--- a/openHABWatch/Views/Rows/RollershutterRow.swift
+++ b/openHABWatch/Views/Rows/RollershutterRow.swift
@@ -23,7 +23,7 @@ struct RollershutterRow: View {
         VStack(spacing: -5) {
             HStack {
                 WatchIconView(model: widget.iconRenderModel(), settings: settings)
-                WatchLabelText(text: widget.labelText ?? widget.label)
+                WatchLabelText(text: widget.labelText ?? widget.label, valueColor: widget.labelcolor)
                 Spacer()
                 DetailTextLabelView(text: widget.labelValue, valueColor: widget.valuecolor)
             }

--- a/openHABWatch/Views/Rows/RollershutterRow.swift
+++ b/openHABWatch/Views/Rows/RollershutterRow.swift
@@ -23,7 +23,7 @@ struct RollershutterRow: View {
         VStack(spacing: -5) {
             HStack {
                 WatchIconView(model: widget.iconRenderModel(), settings: settings)
-                WatchLabelText(text: widget.labelText ?? widget.label, valueColor: widget.labelcolor)
+                WatchLabelText(text: widget.labelText ?? widget.label, labelColor: widget.labelcolor)
                 Spacer()
                 DetailTextLabelView(text: widget.labelValue, valueColor: widget.valuecolor)
             }

--- a/openHABWatch/Views/Rows/SegmentRow.swift
+++ b/openHABWatch/Views/Rows/SegmentRow.swift
@@ -48,7 +48,7 @@ struct SegmentRow: View {
         if viewModel.mappings.count <= 2 {
             HStack {
                 WatchIconView(model: widget.iconRenderModel(), settings: settings)
-                WatchLabelText(text: viewModel.labelText, valueColor: widget.labelcolor)
+                WatchLabelText(text: viewModel.labelText, labelColor: widget.labelcolor)
                 Spacer()
                 pressReleaseButtons
                     .layoutPriority(1)
@@ -102,7 +102,7 @@ struct SegmentRow: View {
     private var iconTitleRow: some View {
         HStack {
             WatchIconView(model: widget.iconRenderModel(), settings: settings)
-            WatchLabelText(text: viewModel.labelText, valueColor: widget.labelcolor)
+            WatchLabelText(text: viewModel.labelText, labelColor: widget.labelcolor)
             Spacer()
         }
     }
@@ -121,7 +121,7 @@ struct SegmentRow: View {
         HStack {
             HStack {
                 WatchIconView(model: widget.iconRenderModel(), settings: settings)
-                WatchLabelText(text: viewModel.labelText, valueColor: widget.labelcolor)
+                WatchLabelText(text: viewModel.labelText, labelColor: widget.labelcolor)
                 Spacer()
             }
             NavigationLink(destination: LazyView(SegmentSelectionView(
@@ -154,7 +154,7 @@ struct SegmentRow: View {
         let mapping = viewModel.mappings[0]
         HStack {
             WatchIconView(model: widget.iconRenderModel(), settings: settings)
-            WatchLabelText(text: viewModel.labelText, valueColor: widget.labelcolor)
+            WatchLabelText(text: viewModel.labelText, labelColor: widget.labelcolor)
             Spacer()
             singleButton(for: mapping)
                 .layoutPriority(1)

--- a/openHABWatch/Views/Rows/SegmentRow.swift
+++ b/openHABWatch/Views/Rows/SegmentRow.swift
@@ -48,7 +48,7 @@ struct SegmentRow: View {
         if viewModel.mappings.count <= 2 {
             HStack {
                 WatchIconView(model: widget.iconRenderModel(), settings: settings)
-                WatchLabelText(text: viewModel.labelText)
+                WatchLabelText(text: viewModel.labelText, valueColor: widget.labelcolor)
                 Spacer()
                 pressReleaseButtons
                     .layoutPriority(1)
@@ -102,7 +102,7 @@ struct SegmentRow: View {
     private var iconTitleRow: some View {
         HStack {
             WatchIconView(model: widget.iconRenderModel(), settings: settings)
-            WatchLabelText(text: viewModel.labelText)
+            WatchLabelText(text: viewModel.labelText, valueColor: widget.labelcolor)
             Spacer()
         }
     }
@@ -121,7 +121,7 @@ struct SegmentRow: View {
         HStack {
             HStack {
                 WatchIconView(model: widget.iconRenderModel(), settings: settings)
-                WatchLabelText(text: viewModel.labelText)
+                WatchLabelText(text: viewModel.labelText, valueColor: widget.labelcolor)
                 Spacer()
             }
             NavigationLink(destination: LazyView(SegmentSelectionView(
@@ -154,7 +154,7 @@ struct SegmentRow: View {
         let mapping = viewModel.mappings[0]
         HStack {
             WatchIconView(model: widget.iconRenderModel(), settings: settings)
-            WatchLabelText(text: viewModel.labelText)
+            WatchLabelText(text: viewModel.labelText, valueColor: widget.labelcolor)
             Spacer()
             singleButton(for: mapping)
                 .layoutPriority(1)

--- a/openHABWatch/Views/Rows/SelectionRow.swift
+++ b/openHABWatch/Views/Rows/SelectionRow.swift
@@ -105,7 +105,7 @@ struct SelectionRow: View {
         HStack {
             HStack {
                 WatchIconView(model: widget.iconRenderModel(), settings: settings)
-                WatchLabelText(text: title)
+                WatchLabelText(text: title, valueColor: widget.labelcolor)
                 Spacer()
             }
             NavigationLink(destination: LazyView(SelectionListView(
@@ -117,7 +117,7 @@ struct SelectionRow: View {
                 HStack(spacing: 4) {
                     if let valueText = selectedValueText {
                         Text(valueText)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(widget.valuecolor.isEmpty ? .secondary : Color(fromString: widget.valuecolor))
                             .watchTextStyle(.secondary)
                     }
                     Image(systemSymbol: .chevronUpChevronDown)
@@ -169,3 +169,4 @@ struct SelectionRow: View {
         )
     }
 }
+

--- a/openHABWatch/Views/Rows/SelectionRow.swift
+++ b/openHABWatch/Views/Rows/SelectionRow.swift
@@ -105,7 +105,7 @@ struct SelectionRow: View {
         HStack {
             HStack {
                 WatchIconView(model: widget.iconRenderModel(), settings: settings)
-                WatchLabelText(text: title, valueColor: widget.labelcolor)
+                WatchLabelText(text: title, labelColor: widget.labelcolor)
                 Spacer()
             }
             NavigationLink(destination: LazyView(SelectionListView(
@@ -169,4 +169,3 @@ struct SelectionRow: View {
         )
     }
 }
-

--- a/openHABWatch/Views/Rows/SetpointRow.swift
+++ b/openHABWatch/Views/Rows/SetpointRow.swift
@@ -52,6 +52,7 @@ struct SetpointRow: View {
                 WatchIconView(model: widget.iconRenderModel(), settings: settings)
                 Text(viewModel.labelText)
                     .watchTextStyle(.label)
+                    .foregroundStyle(widget.labelcolor.isEmpty ? .primary : Color(fromString: widget.labelcolor))
                 Spacer()
             }
             HStack {
@@ -71,6 +72,7 @@ struct SetpointRow: View {
 
                 Text(valueText)
                     .watchTextStyle(.emphasis)
+                    .foregroundStyle(widget.valuecolor.isEmpty ? .primary : Color(fromString: widget.valuecolor))
                     .accessibilityLabel("\(viewModel.labelText) value")
                     .accessibilityValue(valueText)
 

--- a/openHABWatch/Views/Rows/SliderRow.swift
+++ b/openHABWatch/Views/Rows/SliderRow.swift
@@ -82,7 +82,7 @@ struct SliderRow: View {
                     HStack {
                         WatchIconView(model: widget.iconRenderModel(fallbackSymbol: fallbackSymbol), settings: settings)
                         VStack(alignment: .leading) {
-                            WatchLabelText(text: viewModel.labelText)
+                            WatchLabelText(text: viewModel.labelText, valueColor: widget.labelcolor)
                             if pendingValue != nil {
                                 Text(currentValueText)
                                     .watchTextStyle(.secondary)
@@ -98,7 +98,7 @@ struct SliderRow: View {
             } else {
                 HStack {
                     WatchIconView(model: widget.iconRenderModel(fallbackSymbol: fallbackSymbol), settings: settings)
-                    WatchLabelText(text: viewModel.labelText)
+                    WatchLabelText(text: viewModel.labelText, valueColor: widget.labelcolor)
                     Spacer()
                     if pendingValue != nil {
                         Text(currentValueText)

--- a/openHABWatch/Views/Rows/SliderRow.swift
+++ b/openHABWatch/Views/Rows/SliderRow.swift
@@ -82,7 +82,7 @@ struct SliderRow: View {
                     HStack {
                         WatchIconView(model: widget.iconRenderModel(fallbackSymbol: fallbackSymbol), settings: settings)
                         VStack(alignment: .leading) {
-                            WatchLabelText(text: viewModel.labelText, valueColor: widget.labelcolor)
+                            WatchLabelText(text: viewModel.labelText, labelColor: widget.labelcolor)
                             if pendingValue != nil {
                                 Text(currentValueText)
                                     .watchTextStyle(.secondary)
@@ -98,7 +98,7 @@ struct SliderRow: View {
             } else {
                 HStack {
                     WatchIconView(model: widget.iconRenderModel(fallbackSymbol: fallbackSymbol), settings: settings)
-                    WatchLabelText(text: viewModel.labelText, valueColor: widget.labelcolor)
+                    WatchLabelText(text: viewModel.labelText, labelColor: widget.labelcolor)
                     Spacer()
                     if pendingValue != nil {
                         Text(currentValueText)

--- a/openHABWatch/Views/Rows/SwitchRow.swift
+++ b/openHABWatch/Views/Rows/SwitchRow.swift
@@ -39,7 +39,7 @@ struct SwitchRow: View {
             HStack {
                 WatchIconView(model: widget.iconRenderModel(), settings: settings)
                 VStack {
-                    WatchLabelText(text: widget.labelText ?? widget.label)
+                    WatchLabelText(text: widget.labelText ?? widget.label, valueColor: widget.labelcolor)
                     DetailTextLabelView(text: widget.labelValue, valueColor: widget.valuecolor)
                 }
             }

--- a/openHABWatch/Views/Rows/SwitchRow.swift
+++ b/openHABWatch/Views/Rows/SwitchRow.swift
@@ -39,7 +39,7 @@ struct SwitchRow: View {
             HStack {
                 WatchIconView(model: widget.iconRenderModel(), settings: settings)
                 VStack {
-                    WatchLabelText(text: widget.labelText ?? widget.label, valueColor: widget.labelcolor)
+                    WatchLabelText(text: widget.labelText ?? widget.label, labelColor: widget.labelcolor)
                     DetailTextLabelView(text: widget.labelValue, valueColor: widget.valuecolor)
                 }
             }

--- a/openHABWatch/Views/Rows/TextRow.swift
+++ b/openHABWatch/Views/Rows/TextRow.swift
@@ -22,7 +22,7 @@ struct TextRow: View {
     var body: some View {
         HStack {
             WatchIconView(model: widget.iconRenderModel(), settings: settings)
-            WatchLabelText(text: widget.labelText ?? widget.label)
+            WatchLabelText(text: widget.labelText ?? widget.label, valueColor: widget.labelcolor)
             Spacer()
             DetailTextLabelView(text: widget.labelValue, valueColor: widget.valuecolor)
             if hasLinkedPage {

--- a/openHABWatch/Views/Rows/TextRow.swift
+++ b/openHABWatch/Views/Rows/TextRow.swift
@@ -22,7 +22,7 @@ struct TextRow: View {
     var body: some View {
         HStack {
             WatchIconView(model: widget.iconRenderModel(), settings: settings)
-            WatchLabelText(text: widget.labelText ?? widget.label, valueColor: widget.labelcolor)
+            WatchLabelText(text: widget.labelText ?? widget.label, labelColor: widget.labelcolor)
             Spacer()
             DetailTextLabelView(text: widget.labelValue, valueColor: widget.valuecolor)
             if hasLinkedPage {

--- a/openHABWatch/Views/Utils/WatchTypography.swift
+++ b/openHABWatch/Views/Utils/WatchTypography.swift
@@ -13,11 +13,20 @@ import CommonUI
 import SwiftUI
 
 struct WatchLabelText: View {
-    let text: String
+    let text: String?
+    let valueColor: String
 
     var body: some View {
-        Text(text)
-            .watchTextStyle(.label)
+        if let text {
+            Text(text)
+                .watchTextStyle(.label)
+                .foregroundStyle(!valueColor.isEmpty ? Color(fromString: valueColor) : .primary)
+        }
+    }
+    
+    init(text: String?, valueColor: String = "") {
+        self.text = text
+        self.valueColor = valueColor
     }
 }
 

--- a/openHABWatch/Views/Utils/WatchTypography.swift
+++ b/openHABWatch/Views/Utils/WatchTypography.swift
@@ -14,19 +14,19 @@ import SwiftUI
 
 struct WatchLabelText: View {
     let text: String?
-    let valueColor: String
+    let labelColor: String
 
     var body: some View {
         if let text {
             Text(text)
                 .watchTextStyle(.label)
-                .foregroundStyle(!valueColor.isEmpty ? Color(fromString: valueColor) : .primary)
+                .foregroundStyle(!labelColor.isEmpty ? Color(fromString: labelColor) : .primary)
         }
     }
-    
-    init(text: String?, valueColor: String = "") {
+
+    init(text: String?, labelColor: String = "") {
         self.text = text
-        self.valueColor = valueColor
+        self.labelColor = labelColor
     }
 }
 


### PR DESCRIPTION
## Summary

- Renames the `valueColor` parameter in `WatchLabelText` to `labelColor` — the old name was misleading since it holds the label colour, not the value colour (which belongs to `DetailTextLabelView.valueColor`)
- Updates all 8 call sites across the watchOS row views
- Removes a spurious trailing blank line in `SelectionRow.swift`

Follows review of openhab/openhab-ios#1120.