### PR TITLE
ci: fix bundle install permission error in pull request workflow

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -16,9 +16,18 @@ jobs:
 
       - uses: actions/checkout@v6
 
+      - name: Cache Ruby gems
+        uses: actions/cache@v5
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
       - name: Install dependencies
         run: |
-            bundle install --redownload
+          bundle config set path 'vendor/bundle'
+          bundle install
 
       - name: Fastlane unit tests
         env:


### PR DESCRIPTION
## Summary

- Installs gems into `vendor/bundle` instead of the Homebrew system directory to avoid `Errno::EACCES` permission errors on CI runners
- Adds gem caching via `actions/cache` for faster subsequent runs

## Context

`bundle install --redownload` attempts to write to `/opt/homebrew/lib/ruby/gems/` which is not writable on the CI runner. Using `bundle config set path 'vendor/bundle'` installs into a local project directory instead.

This unblocks openhab/openhab-ios#1121 and any other PRs hitting the same failure.