### PR TITLE
Add JavaFormatConverter for Java-to-Swift format string conversion

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Model/NumberState.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/NumberState.swift
@@ -47,31 +47,24 @@ public struct NumberState: CustomStringConvertible, Equatable {
 
     public func toString(locale: Locale?) -> String {
         if let format, !format.isEmpty {
-            var actualFormat = format
-                .replacingOccurrences(of: "%unit%", with: unit ?? "")
-                // %s in Java is for Strings, but does not work in Swift, see
-                // https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Strings/Articles/formatSpecifiers.html)
-                .replacingOccurrences(of: "%s", with: "%@")
+            var javaFormat = format.replacingOccurrences(of: "%unit%", with: unit ?? "")
 
-            // Escape trailing % that isn't already escaped (e.g., "%.0f %" should become "%.0f %%")
-            // This handles server-side format patterns that forgot to escape the percent sign
-            if actualFormat.hasSuffix(" %"), !actualFormat.hasSuffix(" %%") {
-                actualFormat = String(actualFormat.dropLast()) + "%%"
+            // Escape a bare trailing % the server forgot to escape (e.g. "%.0f %")
+            if javaFormat.hasSuffix(" %"), !javaFormat.hasSuffix(" %%") {
+                javaFormat = String(javaFormat.dropLast()) + "%%"
             }
 
-            let formatValue: any CVarArg = if format.contains("%d") {
-                intValue
-            } else if format.contains("%s") {
-                stringValue
-            } else {
-                value
+            if let rendered = JavaFormatConverter.render(javaFormat: javaFormat, value: value, unit: unit, locale: locale) {
+                return rendered
             }
-            return String(format: actualFormat, locale: locale, formatValue)
         }
+        return fallbackString
+    }
+
+    private var fallbackString: String {
         if let unit, !unit.isEmpty {
             return "\(stringValue) \(unit)"
-        } else {
-            return stringValue
         }
+        return stringValue
     }
 }

--- a/OpenHABCore/Sources/OpenHABCore/Util/JavaFormatConverter.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/JavaFormatConverter.swift
@@ -1,0 +1,270 @@
+// Copyright (c) 2010-2026 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+import Foundation
+
+/// Converts Java `java.util.Formatter` printf-style format strings to rendered output
+/// for openHAB Number item states.
+///
+/// Supports the subset of Java format syntax used by openHAB, plus Java-specific
+/// features not available in Swift's `String(format:)`:
+///
+/// | Java feature | Handling |
+/// |---|---|
+/// | `%s` string specifier | mapped to `%@` |
+/// | `%n` newline | → `\n` |
+/// | `%b`/`%B` boolean | → `"true"`/`"false"` |
+/// | `,` grouping-separator flag | via `NumberFormatter` |
+/// | `(` negative-in-parentheses flag | via `NumberFormatter` |
+/// | Positional indices `%1$…` / `%2$…` | arg 1 = value, arg 2 = unit |
+///
+/// The two implicit arguments are always:
+/// - **arg 1** — the numeric `Double` value
+/// - **arg 2** — the unit `String` (may be empty)
+enum JavaFormatConverter {
+    // MARK: - Public API
+
+    /// Renders a Java-style format string with the given numeric value and optional unit.
+    ///
+    /// Returns `nil` if the format string is malformed, uses unsupported specifiers,
+    /// addresses more than two arguments, or mixes incompatible argument types.
+    static func render(javaFormat: String, value: Double, unit: String?, locale: Locale?) -> String? {
+        var result = ""
+        var index = javaFormat.startIndex
+        var nextSequentialArg = 1 // 1-based, matches Java
+
+        while index < javaFormat.endIndex {
+            let ch = javaFormat[index]
+            guard ch == "%" else {
+                result.append(ch)
+                index = javaFormat.index(after: index)
+                continue
+            }
+
+            // Consume '%'
+            index = javaFormat.index(after: index)
+            guard index < javaFormat.endIndex else { return nil }
+
+            // %% → literal %
+            if javaFormat[index] == "%" {
+                result.append("%")
+                index = javaFormat.index(after: index)
+                continue
+            }
+
+            // %n → platform newline (Java) → \n
+            if javaFormat[index] == "n" {
+                result.append("\n")
+                index = javaFormat.index(after: index)
+                continue
+            }
+
+            // --- Optional argument index: digits followed by '$' ---
+            var argIndex: Int?
+            var lookahead = index
+            var digitStr = ""
+            while lookahead < javaFormat.endIndex, javaFormat[lookahead].isNumber {
+                digitStr.append(javaFormat[lookahead])
+                lookahead = javaFormat.index(after: lookahead)
+            }
+            if !digitStr.isEmpty,
+               lookahead < javaFormat.endIndex,
+               javaFormat[lookahead] == "$" {
+                guard let n = Int(digitStr), n >= 1, n <= 2 else { return nil }
+                argIndex = n
+                index = javaFormat.index(after: lookahead) // advance past '$'
+            }
+            // If no '$' found, 'index' is unchanged and 'digitStr' will be re-parsed as width below.
+
+            // --- Flags ---
+            var hasGrouping = false
+            var hasParens = false
+            var hasLeftAlign = false
+            var hasPlus = false
+            var hasSpace = false
+            var hasZeroPad = false
+
+            flagLoop: while index < javaFormat.endIndex {
+                switch javaFormat[index] {
+                case "-": hasLeftAlign = true
+                case "+": hasPlus = true
+                case " ": hasSpace = true
+                case "0": hasZeroPad = true
+                case ",": hasGrouping = true
+                case "(": hasParens = true
+                case "<": return nil // relative index — not supported
+                default: break flagLoop
+                }
+                index = javaFormat.index(after: index)
+            }
+
+            // --- Width ---
+            var widthStr = ""
+            while index < javaFormat.endIndex, javaFormat[index].isNumber {
+                widthStr.append(javaFormat[index])
+                index = javaFormat.index(after: index)
+            }
+            let width = Int(widthStr)
+
+            // --- Precision ---
+            var precision: Int?
+            if index < javaFormat.endIndex, javaFormat[index] == "." {
+                index = javaFormat.index(after: index)
+                var precStr = ""
+                while index < javaFormat.endIndex, javaFormat[index].isNumber {
+                    precStr.append(javaFormat[index])
+                    index = javaFormat.index(after: index)
+                }
+                precision = Int(precStr) ?? 0
+            }
+
+            guard index < javaFormat.endIndex else { return nil }
+            let conversion = javaFormat[index]
+            index = javaFormat.index(after: index)
+
+            // Resolve effective argument index
+            let effectiveArgIndex: Int
+            if let explicit = argIndex {
+                effectiveArgIndex = explicit
+            } else {
+                effectiveArgIndex = nextSequentialArg
+                nextSequentialArg += 1
+            }
+
+            // Swift String(format:) flags (subset safe for Swift)
+            var swiftFlags = ""
+            if hasLeftAlign { swiftFlags += "-" }
+            if hasPlus { swiftFlags += "+" }
+            if hasSpace { swiftFlags += " " }
+            if hasZeroPad { swiftFlags += "0" }
+
+            // Render this specifier
+            let segment: String
+            switch conversion {
+
+            // Integer conversions — arg 1 only
+            case "d", "x", "X", "o":
+                guard effectiveArgIndex == 1 else { return nil }
+                let intVal = Int(value)
+                if hasGrouping || hasParens {
+                    guard let s = renderInteger(intVal, width: width, flags: swiftFlags, grouping: hasGrouping, parens: hasParens, locale: locale) else { return nil }
+                    segment = s
+                } else {
+                    var fmt = "%\(swiftFlags)"
+                    if let w = width { fmt += "\(w)" }
+                    fmt += String(conversion)
+                    segment = String(format: fmt, locale: locale, intVal)
+                }
+
+            // Floating-point conversions — arg 1 only
+            case "f", "F", "e", "E", "g", "G", "a", "A":
+                guard effectiveArgIndex == 1 else { return nil }
+                if hasGrouping || hasParens {
+                    guard let s = renderFloat(value, conversion: conversion, width: width, precision: precision, flags: swiftFlags, grouping: hasGrouping, parens: hasParens, locale: locale) else { return nil }
+                    segment = s
+                } else {
+                    var fmt = "%\(swiftFlags)"
+                    if let w = width { fmt += "\(w)" }
+                    if let p = precision { fmt += ".\(p)" }
+                    fmt += String(conversion)
+                    segment = String(format: fmt, locale: locale, value)
+                }
+
+            // String conversions — arg 1 = value as string, arg 2 = unit
+            case "s", "S":
+                let raw: String = effectiveArgIndex == 2
+                    ? (unit ?? "")
+                    : String(value)
+                let strVal = conversion == "S" ? raw.uppercased() : raw
+                if let w = width, strVal.count < w {
+                    let padding = String(repeating: " ", count: w - strVal.count)
+                    segment = hasLeftAlign ? strVal + padding : padding + strVal
+                } else {
+                    segment = strVal
+                }
+
+            // Boolean — non-zero = true; arg 1 only
+            case "b":
+                guard effectiveArgIndex == 1 else { return nil }
+                segment = value != 0 ? "true" : "false"
+
+            case "B":
+                guard effectiveArgIndex == 1 else { return nil }
+                segment = value != 0 ? "TRUE" : "FALSE"
+
+            default:
+                return nil
+            }
+
+            result.append(segment)
+        }
+
+        return result
+    }
+
+    // MARK: - NumberFormatter-backed rendering
+
+    private static func renderInteger(
+        _ value: Int,
+        width: Int?,
+        flags: String,
+        grouping: Bool,
+        parens: Bool,
+        locale: Locale?
+    ) -> String? {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.usesGroupingSeparator = grouping
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 0
+        if let locale { formatter.locale = locale }
+        if parens, value < 0 {
+            formatter.negativeFormat = "(#,##0)"
+        }
+        guard var s = formatter.string(from: NSNumber(value: value)) else { return nil }
+        if let w = width { s = pad(s, width: w, leftAlign: flags.contains("-")) }
+        return s
+    }
+
+    private static func renderFloat(
+        _ value: Double,
+        conversion: Character,
+        width: Int?,
+        precision: Int?,
+        flags: String,
+        grouping: Bool,
+        parens: Bool,
+        locale: Locale?
+    ) -> String? {
+        let prec = precision ?? 6
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.usesGroupingSeparator = grouping
+        formatter.minimumFractionDigits = prec
+        formatter.maximumFractionDigits = prec
+        if let locale { formatter.locale = locale }
+        if parens, value < 0 {
+            let zeros = String(repeating: "0", count: prec)
+            formatter.negativeFormat = prec > 0 ? "(#,##0.\(zeros))" : "(#,##0)"
+        }
+        guard var s = formatter.string(from: NSNumber(value: value)) else { return nil }
+        if let w = width { s = pad(s, width: w, leftAlign: flags.contains("-")) }
+        return s
+    }
+
+    // MARK: - Padding
+
+    private static func pad(_ s: String, width: Int, leftAlign: Bool) -> String {
+        guard s.count < width else { return s }
+        let padding = String(repeating: " ", count: width - s.count)
+        return leftAlign ? s + padding : padding + s
+    }
+}

--- a/OpenHABCore/Tests/OpenHABCoreTests/NumberStateTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/NumberStateTests.swift
@@ -18,17 +18,48 @@ import UIKit
 struct NumberStateTests {
     @Test("toString formats with display pattern")
     func toStringFormatting() {
+        // Basic specifiers
         #expect(NumberState(value: 100.3, format: "%d").toString(locale: nil) == "100")
         #expect(NumberState(value: 100.4, format: "%d").toString(locale: Locale(identifier: "US")) == "100")
         #expect(NumberState(value: 100.4, format: "%.1f").toString(locale: Locale(identifier: "US")) == "100.4")
         #expect(NumberState(value: 100.4, format: "%.1f").toString(locale: Locale(identifier: "de")) == "100,4")
+
+        // %unit% placeholder
         #expect(NumberState(value: 100.4, unit: "K", format: "%.1f %unit%").toString(locale: Locale(identifier: "US")) == "100.4 K")
         #expect(NumberState(value: 100.4, unit: "", format: "%.1f %unit%").toString(locale: Locale(identifier: "US")) == "100.4 ")
+        #expect(NumberState(value: 100.4, unit: "°C", format: "%.1f %unit%").toString(locale: Locale(identifier: "de")) == "100,4 °C")
+
+        // Fallback when no format
         #expect(NumberState(value: 100.4, unit: "°C", format: nil).toString(locale: Locale(identifier: "US")) == "100.4 °C")
         #expect(NumberState(value: 100.4, unit: nil, format: nil).toString(locale: Locale(identifier: "US")) == "100.4")
-        #expect(NumberState(value: 100.4, unit: "°C", format: "%.1f %unit%").toString(locale: Locale(identifier: "de")) == "100,4 °C")
-        // %,.1f is an invalid format string in Swift
-        #expect(NumberState(value: 100.4, unit: "°C", format: "%,.1f %unit%").toString(locale: Locale(identifier: "de")) == ",.1f °C")
+
+        // %s string specifier (Java-style, arg 1 = value as string)
+        #expect(NumberState(value: 100.4, format: "%s").toString(locale: Locale(identifier: "US")) == "100.4")
+
+        // Positional argument indices: %1$ = value, %2$ = unit
+        #expect(NumberState(value: 100.4, unit: "°C", format: "%1$.1f %2$s").toString(locale: Locale(identifier: "US")) == "100.4 °C")
+        #expect(NumberState(value: 100.4, unit: "°C", format: "%1$.1f %2$s").toString(locale: Locale(identifier: "de")) == "100,4 °C")
+
+        // Grouping-separator flag (Java ',') via NumberFormatter
+        #expect(NumberState(value: 1234.5, unit: "W", format: "%,.1f %unit%").toString(locale: Locale(identifier: "en_US")) == "1,234.5 W")
+        #expect(NumberState(value: 1234.5, unit: "W", format: "%,.1f %unit%").toString(locale: Locale(identifier: "de")) == "1.234,5 W")
+        #expect(NumberState(value: 1234567.0, format: "%,.0f").toString(locale: Locale(identifier: "en_US")) == "1,234,567")
+
+        // Negative-in-parentheses flag
+        #expect(NumberState(value: -42.5, format: "%(,.1f").toString(locale: Locale(identifier: "en_US")) == "(42.5)")
+
+        // %n newline
+        #expect(NumberState(value: 100.4, format: "%.1f%n").toString(locale: Locale(identifier: "en_US")) == "100.4\n")
+
+        // %b boolean
+        #expect(NumberState(value: 1.0, format: "%b").toString(locale: nil) == "true")
+        #expect(NumberState(value: 0.0, format: "%b").toString(locale: nil) == "false")
+
+        // %% literal percent
+        #expect(NumberState(value: 75.0, format: "%.0f%%").toString(locale: nil) == "75%")
+
+        // Fallback for unsupported/malformed patterns
+        #expect(NumberState(value: 100.4, unit: "°C", format: "%.1f / %.1f %unit%").toString(locale: Locale(identifier: "de")) == "100.4 °C")
     }
 
     @Test("commandString preserves full precision regardless of display format")


### PR DESCRIPTION
## Summary

Replaces the ad-hoc format string handling in `NumberState` with a dedicated `JavaFormatConverter` that properly covers the `java.util.Formatter` subset used by openHAB — solving format string incompatibility between Java (server) and Swift (client) once and for all.

### What's new vs the previous approach

The previous `toString(locale:)` used a simple `String(format:)` call after a `%s → %@` substitution, which crashed on patterns like `%,.1f` (grouping separator) and silently produced wrong output for `%1$.1f %2$s` (positional args).

`JavaFormatConverter.render(javaFormat:value:unit:locale:)` fully parses the Java format string and handles:

| Java feature | Handling |
|---|---|
| `%d`, `%f`, `%e`, `%g`, `%x`, `%o` and variants | pass-through to Swift `String(format:)` |
| `%s` / `%S` | mapped to `%@` |
| `%n` newline | → `\n` |
| `%b` / `%B` boolean | → `"true"` / `"false"` |
| `,` grouping-separator flag (`%,.1f`) | via `NumberFormatter` (fully locale-aware) |
| `(` negative-in-parentheses flag | via `NumberFormatter` |
| `%1$…` / `%2$…` positional argument indices | arg 1 = numeric value, arg 2 = unit |
| `%%` literal `%` | ✅ |
| Any malformed / unsupported pattern | safe fallback to plain `value unit` string |

### Fixes

Fixes the production crash reported in Crashlytics (session `4e8df701a2e54e0f9880a9f93833d00f`) where `NumberState.toString(locale:)` at `NumberState.swift:69` passed an invalid format string containing the `,` grouping flag to `String(format:)`, causing `__CFStringAppendFormatCore` to crash on the main thread.

### Notes

- `JavaFormatConverter` has no openHAB-specific dependencies and could be published as a standalone gist — there is currently nothing like it publicly available.
- Date/time specifiers (`%t`/`%T`) are intentionally out of scope for a number state formatter.