### PR TITLE
Feature/color temperature row crash guard

### DIFF
--- a/openHAB/UI/SwiftUI/Rows/ColorTemperaturePickerRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/ColorTemperaturePickerRowView.swift
@@ -16,8 +16,18 @@ import SFSafeSymbols
 import SwiftUI
 
 enum ColorTemperatureRowMath {
-    static let fallbackRange: ClosedRange<Double> = 1000 ... 10000
-    static let fallbackTemperature = 2700.0
+    static let minimumKelvin = 1_000.0
+    static let maximumKelvin = 10_000.0
+    static let warmWhiteKelvin = 2_700.0
+    static let minimumGradientSteps = 1
+    static let minimumSliderStep = 1.0
+    static let minimumValidSpan = 0.0
+    static let minimumConvertibleKelvin = 0.0
+    static let fractionLowerBound = 0.0
+    static let fractionUpperBound = 1.0
+
+    static let fallbackRange: ClosedRange<Double> = minimumKelvin ... maximumKelvin
+    static let fallbackTemperature = warmWhiteKelvin
 
     static func normalizedRange(minValue: Double, maxValue: Double) -> ClosedRange<Double> {
         let lowerCandidate = sanitizeTemperatureValue(minValue) ?? fallbackRange.lowerBound
@@ -41,7 +51,7 @@ enum ColorTemperatureRowMath {
     }
 
     static func gradientTemperatures(for range: ClosedRange<Double>, steps: Int) -> [Double] {
-        let safeSteps = max(steps, 1)
+        let safeSteps = max(steps, minimumGradientSteps)
         let span = range.upperBound - range.lowerBound
         return (0 ... safeSteps).map { index in
             range.lowerBound + (span * Double(index) / Double(safeSteps))
@@ -50,14 +60,14 @@ enum ColorTemperatureRowMath {
 
     static func sliderFraction(value: Double, range: ClosedRange<Double>) -> Double {
         let span = range.upperBound - range.lowerBound
-        guard span.isFinite, span > 0 else { return 0 }
+        guard span.isFinite, span > minimumValidSpan else { return fractionLowerBound }
 
         let fraction = (value - range.lowerBound) / span
-        return fraction.clamped(to: 0 ... 1)
+        return fraction.clamped(to: fractionLowerBound ... fractionUpperBound)
     }
 
     static func sanitizeTemperatureValue(_ value: Double?) -> Double? {
-        guard let value, value.isFinite, value > 0 else { return nil }
+        guard let value, value.isFinite, value > minimumConvertibleKelvin else { return nil }
         let convertedValue = value < fallbackRange.lowerBound ? value.asColorTemperatureInKelvin : value
         return convertedValue.isFinite ? convertedValue : nil
     }
@@ -125,10 +135,10 @@ struct CustomSliderView: View {
                                     isDragging = true
                                     onDragStateChanged(true)
                                 }
-                                guard width > 0 else { return }
+                                guard width > ColorTemperatureRowMath.minimumValidSpan else { return }
                                 let location = gesture.location.x.clamped(to: 0 ... width)
                                 let raw = Double(location / width) * (range.upperBound - range.lowerBound) + range.lowerBound
-                                let safeStep = max(step, 1)
+                                let safeStep = max(step, ColorTemperatureRowMath.minimumSliderStep)
                                 let stepped = (raw / safeStep).rounded() * safeStep
                                 value = stepped.clamped(to: range)
                                 let now = Date()
@@ -162,14 +172,6 @@ private struct ColorTemperaturePickerRowContent: View {
 
     private var temperatureRange: ClosedRange<Double> {
         ColorTemperatureRowMath.normalizedRange(minValue: input.minValue, maxValue: input.maxValue)
-    }
-
-    private var minTemperature: Double {
-        temperatureRange.lowerBound
-    }
-
-    private var maxTemperature: Double {
-        temperatureRange.upperBound
     }
 
     var body: some View {
@@ -225,7 +227,7 @@ private struct ColorTemperaturePickerRowContent: View {
                         // Actual slider
                         CustomSliderView(
                             value: $selectedTemperature,
-                            range: minTemperature ... maxTemperature,
+                            range: temperatureRange,
                             step: 100,
                             onEditingChanged: {
                                 sendTemperatureCommand()
@@ -289,7 +291,9 @@ private struct ColorTemperaturePickerRowContent: View {
 
     private func sendTemperatureCommand() {
         // Send temperature directly as Kelvin value (like Android app)
-        let clampedRoundedTemperature = Int(selectedTemperature.rounded()).clamped(to: Int(minTemperature) ... Int(maxTemperature))
+        let clampedRoundedTemperature = Int(selectedTemperature.rounded()).clamped(
+            to: Int(temperatureRange.lowerBound) ... Int(temperatureRange.upperBound)
+        )
         let command = "\(clampedRoundedTemperature)"
 
         logger.info("Sending color temperature command: \(command)K")

--- a/openHAB/UI/SwiftUI/Rows/ColorTemperaturePickerRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/ColorTemperaturePickerRowView.swift
@@ -15,6 +15,59 @@ import os.log
 import SFSafeSymbols
 import SwiftUI
 
+enum ColorTemperatureRowMath {
+    static let fallbackRange: ClosedRange<Double> = 1000 ... 10000
+    static let fallbackTemperature = 2700.0
+
+    static func normalizedRange(minValue: Double, maxValue: Double) -> ClosedRange<Double> {
+        let lowerCandidate = sanitizeTemperatureValue(minValue) ?? fallbackRange.lowerBound
+        let upperCandidate = sanitizeTemperatureValue(maxValue) ?? fallbackRange.upperBound
+
+        let lower = min(lowerCandidate, upperCandidate).clamped(to: fallbackRange)
+        let upper = max(lowerCandidate, upperCandidate).clamped(to: fallbackRange)
+
+        guard lower.isFinite, upper.isFinite, lower < upper else {
+            return fallbackRange
+        }
+
+        return lower ... upper
+    }
+
+    static func normalizedTemperature(state: String?, serverValue: Double?, range: ClosedRange<Double>) -> Double {
+        let resolvedValue = state.flatMap { parseTemperature(state: $0) }
+            ?? sanitizeTemperatureValue(serverValue)
+            ?? fallbackTemperature
+        return resolvedValue.clamped(to: range)
+    }
+
+    static func gradientTemperatures(for range: ClosedRange<Double>, steps: Int) -> [Double] {
+        let safeSteps = max(steps, 1)
+        let span = range.upperBound - range.lowerBound
+        return (0 ... safeSteps).map { index in
+            range.lowerBound + (span * Double(index) / Double(safeSteps))
+        }
+    }
+
+    static func sliderFraction(value: Double, range: ClosedRange<Double>) -> Double {
+        let span = range.upperBound - range.lowerBound
+        guard span.isFinite, span > 0 else { return 0 }
+
+        let fraction = (value - range.lowerBound) / span
+        return fraction.clamped(to: 0 ... 1)
+    }
+
+    static func sanitizeTemperatureValue(_ value: Double?) -> Double? {
+        guard let value, value.isFinite, value > 0 else { return nil }
+        let convertedValue = value < fallbackRange.lowerBound ? value.asColorTemperatureInKelvin : value
+        return convertedValue.isFinite ? convertedValue : nil
+    }
+
+    private static func parseTemperature(state: String) -> Double? {
+        guard !state.isEmpty else { return nil }
+        return sanitizeTemperatureValue(state.parseAsNumber().value)
+    }
+}
+
 private struct ColorTemperatureRowConfig {
     let input: ColorTemperatureRowInput
     let viewModel: SitemapPageViewModel
@@ -53,7 +106,7 @@ struct CustomSliderView: View {
         GeometryReader { geometry in
             let width = geometry.size.width
             let height = geometry.size.height
-            let normalized = CGFloat((value - range.lowerBound) / (range.upperBound - range.lowerBound))
+            let normalized = CGFloat(ColorTemperatureRowMath.sliderFraction(value: value, range: range))
             let xPos = normalized * width
 
             ZStack(alignment: .leading) {
@@ -72,9 +125,11 @@ struct CustomSliderView: View {
                                     isDragging = true
                                     onDragStateChanged(true)
                                 }
+                                guard width > 0 else { return }
                                 let location = gesture.location.x.clamped(to: 0 ... width)
                                 let raw = Double(location / width) * (range.upperBound - range.lowerBound) + range.lowerBound
-                                let stepped = (raw / step).rounded() * step
+                                let safeStep = max(step, 1)
+                                let stepped = (raw / safeStep).rounded() * safeStep
                                 value = stepped.clamped(to: range)
                                 let now = Date()
                                 if now.timeIntervalSince(lastSendTime) > 0.2 {
@@ -105,13 +160,16 @@ private struct ColorTemperaturePickerRowContent: View {
 
     private let logger = Logger(subsystem: "org.openhab", category: "ColorTemperaturePickerRowView")
 
-    // Use widget's min/max values, similar to Android implementation
+    private var temperatureRange: ClosedRange<Double> {
+        ColorTemperatureRowMath.normalizedRange(minValue: input.minValue, maxValue: input.maxValue)
+    }
+
     private var minTemperature: Double {
-        input.clampedMinTemperature
+        temperatureRange.lowerBound
     }
 
     private var maxTemperature: Double {
-        input.clampedMaxTemperature
+        temperatureRange.upperBound
     }
 
     var body: some View {
@@ -188,7 +246,7 @@ private struct ColorTemperaturePickerRowContent: View {
             }
         }
         .onAppear {
-            selectedTemperature = loadCurrentTemperature(state: displayState.effectiveState) ?? input.serverValue ?? 2700
+            selectedTemperature = loadCurrentTemperature(state: displayState.effectiveState)
         }
         .onChange(of: displayState.effectiveState) { newState in
             guard !isDraggingSlider else { return }
@@ -196,7 +254,7 @@ private struct ColorTemperaturePickerRowContent: View {
                 suppressNextServerSync = false
                 return
             }
-            selectedTemperature = loadCurrentTemperature(state: newState) ?? input.serverValue ?? 2700
+            selectedTemperature = loadCurrentTemperature(state: newState)
         }
         .onDisappear {
             onCancelPending(input.colorTemperatureCommandKey)
@@ -218,15 +276,15 @@ private struct ColorTemperaturePickerRowContent: View {
 
     // Generate gradient colors similar to Android implementation
     private func colorTemperatureGradient(steps: Int = 20) -> [Color] {
-        stride(from: minTemperature, through: maxTemperature, by: (maxTemperature - minTemperature) / Double(steps)).map { Color(temperature: $0) }
+        ColorTemperatureRowMath.gradientTemperatures(for: temperatureRange, steps: steps).map { Color(temperature: $0) }
     }
 
-    private func loadCurrentTemperature(state: String?) -> Double? {
-        guard let state, !state.isEmpty else { return nil }
-
-        // Parse color temperature directly from Kelvin value (like Android app)
-        let kelvin = state.parseAsNumber().value
-        return kelvin.clamped(to: minTemperature ... maxTemperature)
+    private func loadCurrentTemperature(state: String?) -> Double {
+        ColorTemperatureRowMath.normalizedTemperature(
+            state: state,
+            serverValue: input.serverValue,
+            range: temperatureRange
+        )
     }
 
     private func sendTemperatureCommand() {

--- a/openHABTestsSwift/ColorTemperatureRowMathTests.swift
+++ b/openHABTestsSwift/ColorTemperatureRowMathTests.swift
@@ -1,0 +1,75 @@
+// Copyright (c) 2010-2026 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+@testable import openHAB
+
+import Testing
+
+@Suite
+struct ColorTemperatureRowMathTests {
+    @Test
+    func normalizedRangeUsesFallbackForZeroSpan() {
+        let range = ColorTemperatureRowMath.normalizedRange(minValue: 15000, maxValue: 15000)
+
+        #expect(range.lowerBound == 1000)
+        #expect(range.upperBound == 10000)
+    }
+
+    @Test
+    func normalizedRangeConvertsMiredBoundsToKelvin() {
+        let range = ColorTemperatureRowMath.normalizedRange(minValue: 370, maxValue: 153)
+
+        #expect(abs(range.lowerBound - 2702.7027027027025) < 0.0001)
+        #expect(abs(range.upperBound - 6535.947712418301) < 0.0001)
+    }
+
+    @Test
+    func normalizedTemperatureConvertsMiredStateAndClampsIntoRange() {
+        let range = ColorTemperatureRowMath.normalizedRange(minValue: 370, maxValue: 153)
+
+        let temperature = ColorTemperatureRowMath.normalizedTemperature(
+            state: "250",
+            serverValue: nil,
+            range: range
+        )
+
+        #expect(temperature == 4000)
+    }
+
+    @Test
+    func normalizedTemperatureFallsBackToClampedServerValue() {
+        let range = ColorTemperatureRowMath.normalizedRange(minValue: 1000, maxValue: 6500)
+
+        let temperature = ColorTemperatureRowMath.normalizedTemperature(
+            state: "not-a-number",
+            serverValue: 9000,
+            range: range
+        )
+
+        #expect(temperature == 6500)
+    }
+
+    @Test
+    func sliderFractionReturnsZeroForDegenerateRange() {
+        let fraction = ColorTemperatureRowMath.sliderFraction(value: 3000, range: 4000 ... 4000)
+
+        #expect(fraction == 0)
+    }
+
+    @Test
+    func gradientTemperaturesAlwaysIncludeBothBounds() {
+        let temperatures = ColorTemperatureRowMath.gradientTemperatures(for: 2000 ... 3000, steps: 4)
+
+        #expect(temperatures.count == 5)
+        #expect(temperatures.first == 2000)
+        #expect(temperatures.last == 3000)
+    }
+}

--- a/openHABTestsSwift/ColorTemperatureRowMathTests.swift
+++ b/openHABTestsSwift/ColorTemperatureRowMathTests.swift
@@ -13,63 +13,103 @@
 
 import Testing
 
+private enum TestValues {
+    static let oversizedKelvin = 15_000.0
+    static let miredWarmest = 370.0
+    static let miredCoolest = 153.0
+    static let convertedWarmestKelvin = 2702.7027027027025
+    static let convertedCoolestKelvin = 6535.947712418301
+    static let miredState = "250"
+    static let convertedStateKelvin = 4_000.0
+    static let invalidState = "not-a-number"
+    static let clampedServerValue = 6_500.0
+    static let oversizedServerValue = 9_000.0
+    static let minimumRangeKelvin = 1_000.0
+    static let narrowMaximumKelvin = 6_500.0
+    static let degenerateRangeKelvin = 4_000.0
+    static let gradientStartKelvin = 2_000.0
+    static let gradientEndKelvin = 3_000.0
+    static let gradientSteps = 4
+    static let gradientCount = 5
+    static let tolerance = 0.0001
+    static let zero = 0.0
+}
+
 @Suite
 struct ColorTemperatureRowMathTests {
     @Test
     func normalizedRangeUsesFallbackForZeroSpan() {
-        let range = ColorTemperatureRowMath.normalizedRange(minValue: 15000, maxValue: 15000)
+        let range = ColorTemperatureRowMath.normalizedRange(
+            minValue: TestValues.oversizedKelvin,
+            maxValue: TestValues.oversizedKelvin
+        )
 
-        #expect(range.lowerBound == 1000)
-        #expect(range.upperBound == 10000)
+        #expect(range.lowerBound == ColorTemperatureRowMath.minimumKelvin)
+        #expect(range.upperBound == ColorTemperatureRowMath.maximumKelvin)
     }
 
     @Test
     func normalizedRangeConvertsMiredBoundsToKelvin() {
-        let range = ColorTemperatureRowMath.normalizedRange(minValue: 370, maxValue: 153)
+        let range = ColorTemperatureRowMath.normalizedRange(
+            minValue: TestValues.miredWarmest,
+            maxValue: TestValues.miredCoolest
+        )
 
-        #expect(abs(range.lowerBound - 2702.7027027027025) < 0.0001)
-        #expect(abs(range.upperBound - 6535.947712418301) < 0.0001)
+        #expect(abs(range.lowerBound - TestValues.convertedWarmestKelvin) < TestValues.tolerance)
+        #expect(abs(range.upperBound - TestValues.convertedCoolestKelvin) < TestValues.tolerance)
     }
 
     @Test
     func normalizedTemperatureConvertsMiredStateAndClampsIntoRange() {
-        let range = ColorTemperatureRowMath.normalizedRange(minValue: 370, maxValue: 153)
+        let range = ColorTemperatureRowMath.normalizedRange(
+            minValue: TestValues.miredWarmest,
+            maxValue: TestValues.miredCoolest
+        )
 
         let temperature = ColorTemperatureRowMath.normalizedTemperature(
-            state: "250",
+            state: TestValues.miredState,
             serverValue: nil,
             range: range
         )
 
-        #expect(temperature == 4000)
+        #expect(temperature == TestValues.convertedStateKelvin)
     }
 
     @Test
     func normalizedTemperatureFallsBackToClampedServerValue() {
-        let range = ColorTemperatureRowMath.normalizedRange(minValue: 1000, maxValue: 6500)
+        let range = ColorTemperatureRowMath.normalizedRange(
+            minValue: TestValues.minimumRangeKelvin,
+            maxValue: TestValues.narrowMaximumKelvin
+        )
 
         let temperature = ColorTemperatureRowMath.normalizedTemperature(
-            state: "not-a-number",
-            serverValue: 9000,
+            state: TestValues.invalidState,
+            serverValue: TestValues.oversizedServerValue,
             range: range
         )
 
-        #expect(temperature == 6500)
+        #expect(temperature == TestValues.clampedServerValue)
     }
 
     @Test
     func sliderFractionReturnsZeroForDegenerateRange() {
-        let fraction = ColorTemperatureRowMath.sliderFraction(value: 3000, range: 4000 ... 4000)
+        let fraction = ColorTemperatureRowMath.sliderFraction(
+            value: TestValues.gradientEndKelvin,
+            range: TestValues.degenerateRangeKelvin ... TestValues.degenerateRangeKelvin
+        )
 
-        #expect(fraction == 0)
+        #expect(fraction == TestValues.zero)
     }
 
     @Test
     func gradientTemperaturesAlwaysIncludeBothBounds() {
-        let temperatures = ColorTemperatureRowMath.gradientTemperatures(for: 2000 ... 3000, steps: 4)
+        let temperatures = ColorTemperatureRowMath.gradientTemperatures(
+            for: TestValues.gradientStartKelvin ... TestValues.gradientEndKelvin,
+            steps: TestValues.gradientSteps
+        )
 
-        #expect(temperatures.count == 5)
-        #expect(temperatures.first == 2000)
-        #expect(temperatures.last == 3000)
+        #expect(temperatures.count == TestValues.gradientCount)
+        #expect(temperatures.first == TestValues.gradientStartKelvin)
+        #expect(temperatures.last == TestValues.gradientEndKelvin)
     }
 }


### PR DESCRIPTION
There is bug reported via Crashlytics: 

## Summary

- Guard against NaN propagation in `CustomSliderView` when `minValue == maxValue` produces a zero-span range, causing `.position(x: NaN)` to crash SwiftUI's layout engine during `preferredLayoutAttributesFitting`
- Replace `stride(from:through:by: 0)` in gradient generation with an integer-step approach safe for zero spans
- Extract all temperature math into a pure, testable `ColorTemperatureRowMath` enum with unit tests covering degenerate range, mired conversion, server value fallback, and fraction clamping

## Test plan

- [ ] `ColorTemperatureRowMathTests` passes (normalizedRange fallback, mired conversion, server value fallback, degenerate fraction, gradient bounds)
- [ ] Color temperature row renders correctly for normal Kelvin ranges
- [ ] Color temperature row renders correctly for mired-unit ranges (e.g. min=370, max=153)
- [ ] No crash when a widget reports identical min and max temperature values