### PR TITLE
Fix clipped Sitemap top left interaction indicator

### DIFF
--- a/openHAB/UI/SwiftUI/SitemapNavigationView.swift
+++ b/openHAB/UI/SwiftUI/SitemapNavigationView.swift
@@ -50,6 +50,8 @@ struct SitemapNavigationView: View {
                 if !isInteractionIdle {
                     ToolbarItem(placement: .navigationBarLeading) {
                         interactionIndicator
+                            .padding(6)
+                            .fixedSize(horizontal: true, vertical: false)
                     }
                 }
                 if viewModel.showSearchField {


### PR DESCRIPTION
https://github.com/openhab/openhab-ios/issues/1118

<img width="897" height="135" alt="Screenshot 2026-04-08 at 19 07 37" src="https://github.com/user-attachments/assets/3a15313f-4dc0-4347-bfbf-79db30ee5b98" />

<img width="1320" height="257" alt="Simulator Screenshot - ScreenshotiPhone17ProMax - 2026-04-08 at 19 03 19" src="https://github.com/user-attachments/assets/1238deed-ec84-4942-9086-b635762647f9" />

<img width="1014" height="532" alt="Screenshot 2026-04-08 at 19 00 35" src="https://github.com/user-attachments/assets/549d7e9b-3f67-45ee-b65b-00462e44d490" />
