### PR TITLE
Fix sitemap scroll hitching under frequent long-poll updates

### DIFF
--- a/openHAB/Models/SitemapPageViewModel.swift
+++ b/openHAB/Models/SitemapPageViewModel.swift
@@ -267,32 +267,48 @@ class SitemapPageViewModel: ObservableObject {
 
     func rebuildRowInputs() {
         let pageKey = "\(defaultSitemap)|\(pageId)"
-        var occurrenceByWidgetID: [String: Int] = [:]
-        var inputs: [SitemapRowInput] = []
-        var index: [RowID: OpenHABWidget] = [:]
-        inputs.reserveCapacity(relevantWidgets.count)
-        index.reserveCapacity(relevantWidgets.count)
+        let widgets = relevantWidgets
+        let inputs = SitemapRowInputMapper.map(pageKey: pageKey, widgets: widgets)
+        rowWidgetIndex = buildWidgetIndex(pageKey: pageKey, widgets: widgets)
+        if inputs != rowInputs {
+            rowInputs = inputs
+        }
+    }
 
-        for widget in relevantWidgets {
+    private func buildWidgetIndex(pageKey: String, widgets: [OpenHABWidget]) -> [RowID: OpenHABWidget] {
+        var occurrenceByWidgetID: [String: Int] = [:]
+        var index: [RowID: OpenHABWidget] = [:]
+        index.reserveCapacity(widgets.count)
+        for widget in widgets {
             let identityWidgetID = SitemapRowInputMapper.rowIdentityWidgetID(for: widget)
             occurrenceByWidgetID[identityWidgetID, default: 0] += 1
             let occurrence = occurrenceByWidgetID[identityWidgetID]!
             let rowID = RowID(pageKey: pageKey, widgetId: identityWidgetID, occurrence: occurrence)
-            let input = SitemapRowInputMapper.map(widget: widget, rowID: rowID)
-            inputs.append(input)
             index[rowID] = widget
         }
+        return index
+    }
 
-        rowWidgetIndex = index
-        rowInputs = inputs
+    /// Increments `widgetUpdateVersions` for each row whose content differs between `oldInputs`
+    /// and `newInputs`, keyed by full row identity.
+    func bumpWidgetVersions(from oldInputs: [SitemapRowInput], to newInputs: [SitemapRowInput]) {
+        if newInputs.count == oldInputs.count {
+            for (new, old) in zip(newInputs, oldInputs) where new != old {
+                widgetUpdateVersions[new.rowID.rawValue, default: 0] += 1
+            }
+        } else {
+            for input in newInputs {
+                widgetUpdateVersions[input.rowID.rawValue, default: 0] += 1
+            }
+        }
     }
 
     func widget(for rowID: RowID) -> OpenHABWidget? {
         rowWidgetIndex[rowID]
     }
 
-    func widgetUpdateVersion(for widgetId: String) -> Int {
-        widgetUpdateVersions[widgetId] ?? 0
+    func widgetUpdateVersion(for rowID: RowID) -> Int {
+        widgetUpdateVersions[rowID.rawValue] ?? 0
     }
 
     func sliderOverrideValue(for itemname: String?) -> Double? {
@@ -528,34 +544,51 @@ extension SitemapPageViewModel {
     @MainActor
     private func updateUI(with page: OpenHABPage, origin: PageUpdateOrigin) {
         logger.debug("Incoming sitemap update origin=\(origin.rawValue, privacy: .public), widgets=\(page.widgets.count)")
-        let newWidgets = page.widgets
 
-        // Check if list structure changed (count, order, or IDs)
+        let pageKey = "\(defaultSitemap)|\(pageId)"
+
+        // Snapshot what the list would render from the new data — before any widget mutation.
+        let incomingFiltered: [OpenHABWidget]
+        if searchText.isEmpty {
+            incomingFiltered = page.widgets
+        } else {
+            incomingFiltered = page.widgets.filter {
+                $0.label.lowercased().contains(searchText.lowercased()) && $0.type != .frame
+            }
+        }
+        let previewInputs = SitemapRowInputMapper.map(pageKey: pageKey, widgets: incomingFiltered)
+
+        let titleChanged = currentPage == nil || currentPage?.title != page.title
+        let canSkipReconciliation = searchText.isEmpty && previewInputs == rowInputs && !titleChanged
+        guard !canSkipReconciliation else {
+            _ = clearSyncedSliderOverrides(using: page.widgets)
+            return
+        }
+
+        // Something changed — reconcile widget objects and update stored state.
         let currentWidgets = currentPage?.widgets ?? []
-        let structureChanged = currentWidgets.count != newWidgets.count
-            || !zip(currentWidgets, newWidgets).allSatisfy { $0.widgetId == $1.widgetId }
-        let reconciledWidgets = reconcileWidgets(newWidgets, with: currentWidgets)
+        let structureChanged = currentWidgets.count != page.widgets.count
+            || !zip(currentWidgets, page.widgets).allSatisfy { $0.widgetId == $1.widgetId }
+        let reconciledWidgets = reconcileWidgets(page.widgets, with: currentWidgets)
+        injectSendCommand(for: reconciledWidgets)
 
-        // Only replace currentPage when structure or title changed
-        if structureChanged || currentPage?.title != page.title || currentPage == nil {
+        if structureChanged || titleChanged {
             page.widgets = reconciledWidgets
-            injectSendCommand(for: reconciledWidgets)
             currentPage = page
         } else {
             currentPage?.widgets = reconciledWidgets
-            // Inject sendCommand into existing widgets without replacing the page
-            injectSendCommand(for: reconciledWidgets)
         }
 
-        trackWidgetUpdates(in: reconciledWidgets)
         _ = clearSyncedSliderOverrides(using: reconciledWidgets)
-        rebuildRowInputs()
-    }
 
-    private func trackWidgetUpdates(in widgets: [OpenHABWidget]) {
-        for widget in widgets {
-            widgetUpdateVersions[widget.widgetId, default: 0] += 1
-        }
+        // Rebuild command-dispatch index from the now-current reconciled widgets.
+        rowWidgetIndex = buildWidgetIndex(pageKey: pageKey, widgets: relevantWidgets)
+
+        // Bump widget versions only for rows whose content actually changed.
+        bumpWidgetVersions(from: rowInputs, to: previewInputs)
+
+        // Publish new row inputs — guaranteed to differ from current (checked above).
+        rowInputs = previewInputs
     }
 
     private func clearSyncedSliderOverrides(using widgets: [OpenHABWidget]) -> Int {

--- a/openHAB/UI/SwiftUI/Rows/ImageRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/ImageRowView.swift
@@ -54,7 +54,7 @@ private struct ImageRowContent: View {
     }
 
     private var chartWidgetVersion: Int {
-        viewModel.widgetUpdateVersion(for: input.widgetId)
+        viewModel.widgetUpdateVersion(for: input.rowID)
     }
 
     private var chartSyncToken: String {

--- a/openHAB/UI/SwiftUI/Rows/SegmentedRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/SegmentedRowView.swift
@@ -344,7 +344,7 @@ struct SegmentedRowView: View {
     var body: some View {
         SegmentedRowContent(
             input: input,
-            widgetVersion: viewModel.widgetUpdateVersion(for: input.widgetId),
+            widgetVersion: viewModel.widgetUpdateVersion(for: input.rowID),
             fallbackSymbol: fallbackSymbol
         ) { command, policy, phase in
             guard let itemName = input.itemName else { return }
@@ -377,13 +377,16 @@ private extension SegmentedRowView {
                                    icon: String = "switch",
                                    mappings: [OpenHABWidgetMapping],
                                    selectedState: String? = nil) -> SegmentedRowInput {
-        SegmentedRowInput.from(widget: PreviewWidgetFactory.segmented(
-            label: label,
-            mappings: mappings,
-            selectedState: selectedState,
-            icon: icon,
-            valueText: detailLabel
-        ))
+        SegmentedRowInput.from(
+            widget: PreviewWidgetFactory.segmented(
+                label: label,
+                mappings: mappings,
+                selectedState: selectedState,
+                icon: icon,
+                valueText: detailLabel
+            ),
+            rowID: RowID(pageKey: "preview", widgetId: UUID().uuidString, occurrence: 1)
+        )
     }
 }
 
@@ -577,7 +580,10 @@ private extension SegmentedRowView {
 #Preview("From PreviewConstants") {
     PreviewList {
         SegmentedRowView(
-            input: SegmentedRowInput.from(widget: PreviewConstants.openHABSitemapPage!.widgets[4])
+            input: SegmentedRowInput.from(
+                widget: PreviewConstants.openHABSitemapPage!.widgets[4],
+                rowID: RowID(pageKey: "preview", widgetId: UUID().uuidString, occurrence: 1)
+            )
         )
     }
 }

--- a/openHAB/UI/SwiftUI/Rows/SelectionRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/SelectionRowView.swift
@@ -178,7 +178,7 @@ struct SelectionRowView: View {
     var body: some View {
         SelectionRowContent(
             input: input,
-            widgetVersion: viewModel.widgetUpdateVersion(for: input.widgetId)
+            widgetVersion: viewModel.widgetUpdateVersion(for: input.rowID)
         ) { command in
             guard let itemName = input.itemName else { return }
             viewModel.sendCommand(command, for: itemName)

--- a/openHAB/UI/SwiftUI/Rows/SliderRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/SliderRowView.swift
@@ -218,7 +218,7 @@ struct SliderRowView: View {
         makeSliderRowContent(
             SliderRowConfig(
                 input: input,
-                widgetVersion: viewModel.widgetUpdateVersion(for: input.widgetId),
+                widgetVersion: viewModel.widgetUpdateVersion(for: input.rowID),
                 overrideValue: viewModel.sliderOverrideValue(for: input.itemName),
                 fallbackSymbol: fallbackSymbol,
                 viewModel: viewModel
@@ -245,7 +245,7 @@ private extension SliderRowView {
             step: step,
             icon: icon,
             switchSupport: switchSupport
-        ))
+        ), rowID: RowID(pageKey: "preview", widgetId: UUID().uuidString, occurrence: 1))
     }
 }
 
@@ -335,7 +335,10 @@ private extension SliderRowView {
 #Preview("From PreviewConstants") {
     PreviewList {
         SliderRowView(
-            input: SliderRowInput.from(widget: PreviewConstants.openHABSitemapPage!.widgets[3]),
+            input: SliderRowInput.from(
+                widget: PreviewConstants.openHABSitemapPage!.widgets[3],
+                rowID: RowID(pageKey: "preview", widgetId: UUID().uuidString, occurrence: 1)
+            ),
             fallbackSymbol: .sliderHorizontal3
         )
     }

--- a/openHAB/UI/SwiftUI/SitemapRowInputMapper.swift
+++ b/openHAB/UI/SwiftUI/SitemapRowInputMapper.swift
@@ -37,11 +37,11 @@ enum SitemapRowInputMapper {
 
         switch widget.renderingKind {
         case .slider:
-            return SitemapRowInput.slider(rowID, SliderRowInput.from(widget: widget))
+            return SitemapRowInput.slider(rowID, SliderRowInput.from(widget: widget, rowID: rowID))
         case .selection:
-            return SitemapRowInput.selection(rowID, SelectionRowInput.from(widget: widget))
+            return SitemapRowInput.selection(rowID, SelectionRowInput.from(widget: widget, rowID: rowID))
         case .segmentedSwitch:
-            return SitemapRowInput.segmented(rowID, SegmentedRowInput.from(widget: widget))
+            return SitemapRowInput.segmented(rowID, SegmentedRowInput.from(widget: widget, rowID: rowID))
         case .frame:
             return SitemapRowInput.frame(rowID, FrameRowInput.from(widget: widget))
         case .text:
@@ -57,7 +57,7 @@ enum SitemapRowInputMapper {
         case .colorPicker:
             return SitemapRowInput.colorPicker(rowID, ColorPickerRowInput.from(widget: widget))
         case .image, .chart, .video, .webview, .mapview:
-            return SitemapRowInput.media(rowID, MediaRowInput.from(widget: widget))
+            return SitemapRowInput.media(rowID, MediaRowInput.from(widget: widget, rowID: rowID))
         case .colorTemperaturePicker:
             return SitemapRowInput.colorTemperature(rowID, ColorTemperatureRowInput.from(widget: widget))
         case .buttonGrid:

--- a/openHAB/UI/SwiftUI/WidgetRowInputs.swift
+++ b/openHAB/UI/SwiftUI/WidgetRowInputs.swift
@@ -44,6 +44,7 @@ struct RowIconInput: Equatable, Sendable {
 }
 
 struct SelectionRowInput: Equatable, RowWithIconInput {
+    let rowID: RowID
     let displayState: WidgetDisplayState
     let mappings: [OpenHABWidgetMapping]
     let labelColor: String
@@ -53,9 +54,10 @@ struct SelectionRowInput: Equatable, RowWithIconInput {
     let icon: RowIconInput
     let itemName: String?
 
-    static func from(widget: OpenHABWidget) -> SelectionRowInput {
+    static func from(widget: OpenHABWidget, rowID: RowID) -> SelectionRowInput {
         let displayState = widget.displayState
         return SelectionRowInput(
+            rowID: rowID,
             displayState: displayState,
             mappings: displayState.mappings,
             labelColor: widget.labelcolor,
@@ -69,6 +71,7 @@ struct SelectionRowInput: Equatable, RowWithIconInput {
 }
 
 struct SegmentedRowInput: Equatable, RowWithIconInput {
+    let rowID: RowID
     let displayState: WidgetDisplayState
     let mappings: [OpenHABWidgetMapping]
     let labelColor: String
@@ -77,9 +80,10 @@ struct SegmentedRowInput: Equatable, RowWithIconInput {
     let icon: RowIconInput
     let itemName: String?
 
-    static func from(widget: OpenHABWidget) -> SegmentedRowInput {
+    static func from(widget: OpenHABWidget, rowID: RowID) -> SegmentedRowInput {
         let displayState = widget.displayState
         return SegmentedRowInput(
+            rowID: rowID,
             displayState: displayState,
             mappings: displayState.mappings,
             labelColor: widget.labelcolor,
@@ -408,6 +412,7 @@ struct ColorTemperatureRowInput: Equatable, RowWithIconInput {
 }
 
 struct MediaRowInput: Equatable {
+    let rowID: RowID
     let widgetId: String
     let renderingKind: WidgetRenderingKind
     let displayState: WidgetDisplayState
@@ -423,12 +428,13 @@ struct MediaRowInput: Equatable {
     let coordinateLatitude: Double?
     let coordinateLongitude: Double?
 
-    static func from(widget: OpenHABWidget) -> MediaRowInput {
+    static func from(widget: OpenHABWidget, rowID: RowID) -> MediaRowInput {
         let coordinate = widget.coordinate
         let hasValidCoordinate = (-90.0 ... 90.0).contains(coordinate.latitude)
             && (-180.0 ... 180.0).contains(coordinate.longitude)
 
         return MediaRowInput(
+            rowID: rowID,
             widgetId: widget.widgetId,
             renderingKind: widget.renderingKind,
             displayState: widget.displayState,
@@ -478,6 +484,7 @@ struct TextRowInput: Equatable, RowWithIconInput {
 }
 
 struct SliderRowInput: Equatable, RowWithIconInput {
+    let rowID: RowID
     let widgetId: String
     let displayState: WidgetDisplayState
     let numberPattern: String?
@@ -500,7 +507,7 @@ struct SliderRowInput: Equatable, RowWithIconInput {
         displayState.minValue ... displayState.maxValue
     }
 
-    static func from(widget: OpenHABWidget) -> SliderRowInput {
+    static func from(widget: OpenHABWidget, rowID: RowID) -> SliderRowInput {
         let displayState = widget.displayState
         let numberPattern = if let pattern = widget.pattern, !pattern.isEmpty {
             pattern
@@ -515,6 +522,7 @@ struct SliderRowInput: Equatable, RowWithIconInput {
         }
 
         return SliderRowInput(
+            rowID: rowID,
             widgetId: widget.widgetId,
             displayState: displayState,
             numberPattern: numberPattern,

--- a/openHABTestsSwift/SitemapPageViewModelDiffingTests.swift
+++ b/openHABTestsSwift/SitemapPageViewModelDiffingTests.swift
@@ -1,0 +1,185 @@
+// Copyright (c) 2010-2026 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+@testable import openHAB
+import Combine
+import OpenHABCore
+import Testing
+
+/// Tests that the row-input and widget-version pipelines avoid unnecessary
+/// @Published writes when incoming data is unchanged.
+@MainActor
+@Suite
+struct SitemapPageViewModelDiffingTests {
+    // MARK: rowInputs diffing
+
+    @Test
+    func rebuildRowInputsProducesStableOutputForUnchangedWidgets() {
+        let widgets = [makeTextWidget(widgetID: "w1", label: "Light"), makeTextWidget(widgetID: "w2", label: "Temp")]
+        let viewModel = SitemapPageViewModel(title: "Test", widgets: widgets)
+
+        let first = viewModel.rowInputs
+        viewModel.rebuildRowInputs()
+        let second = viewModel.rowInputs
+
+        #expect(first == second)
+    }
+
+    @Test
+    func rebuildRowInputsDoesNotFireObjectWillChangeWhenUnchanged() {
+        let widgets = [makeTextWidget(widgetID: "w1", label: "Light")]
+        let viewModel = SitemapPageViewModel(title: "Test", widgets: widgets)
+
+        var changeCount = 0
+        let cancellable = viewModel.objectWillChange.sink { changeCount += 1 }
+
+        let countBefore = changeCount
+        // Second rebuild with identical widgets — guard should suppress the assignment.
+        viewModel.rebuildRowInputs()
+        #expect(changeCount == countBefore)
+
+        withExtendedLifetime(cancellable) {}
+    }
+
+    @Test
+    func rebuildRowInputsFiresObjectWillChangeWhenWidgetsChange() {
+        let widget = makeTextWidget(widgetID: "w1", label: "Light")
+        let viewModel = SitemapPageViewModel(title: "Test", widgets: [widget])
+
+        var changeCount = 0
+        let cancellable = viewModel.objectWillChange.sink { changeCount += 1 }
+
+        let countBefore = changeCount
+
+        // Swap in a differently-labelled widget and rebuild.
+        let changed = makeTextWidget(widgetID: "w1", label: "Updated")
+        viewModel.currentPage = makePage(widgets: [changed])
+        viewModel.rebuildRowInputs()
+
+        #expect(changeCount > countBefore)
+
+        withExtendedLifetime(cancellable) {}
+    }
+
+    @Test
+    func rebuildRowInputsHandlesStructureChange() {
+        let widgets = [makeTextWidget(widgetID: "w1", label: "One"), makeTextWidget(widgetID: "w2", label: "Two")]
+        let viewModel = SitemapPageViewModel(title: "Test", widgets: widgets)
+
+        #expect(viewModel.rowInputs.count == 2)
+
+        viewModel.currentPage = makePage(widgets: [makeTextWidget(widgetID: "w1", label: "One")])
+        viewModel.rebuildRowInputs()
+
+        #expect(viewModel.rowInputs.count == 1)
+    }
+
+    // MARK: bumpWidgetVersions
+
+    @Test
+    func bumpWidgetVersionsDoesNotIncrementForIdenticalInputs() {
+        let viewModel = SitemapPageViewModel(title: "Test", widgets: [makeTextWidget(widgetID: "w1", label: "Temp")])
+        let inputs = viewModel.rowInputs
+        let before = viewModel.widgetUpdateVersion(for: inputs[0].rowID)
+
+        viewModel.bumpWidgetVersions(from: inputs, to: inputs)
+
+        #expect(viewModel.widgetUpdateVersion(for: inputs[0].rowID) == before)
+    }
+
+    @Test
+    func bumpWidgetVersionsIncrementsOnlyForChangedRow() {
+        let w1 = makeTextWidget(widgetID: "w1", label: "Stable")
+        let w2 = makeTextWidget(widgetID: "w2", label: "Changing")
+        let viewModel = SitemapPageViewModel(title: "Test", widgets: [w1, w2])
+
+        let oldInputs = viewModel.rowInputs
+
+        // Rebuild with w2 changed.
+        viewModel.currentPage = makePage(widgets: [w1, makeTextWidget(widgetID: "w2", label: "Updated")])
+        viewModel.rebuildRowInputs()
+        let newInputs = viewModel.rowInputs
+
+        let v1Before = viewModel.widgetUpdateVersion(for: oldInputs[0].rowID)
+        let v2Before = viewModel.widgetUpdateVersion(for: oldInputs[1].rowID)
+
+        viewModel.bumpWidgetVersions(from: oldInputs, to: newInputs)
+
+        #expect(viewModel.widgetUpdateVersion(for: newInputs[0].rowID) == v1Before, "Stable widget version must not change")
+        #expect(viewModel.widgetUpdateVersion(for: newInputs[1].rowID) > v2Before, "Changed widget version must increment")
+    }
+
+    @Test
+    func bumpWidgetVersionsIncrementsAllRowsOnStructureChange() {
+        let viewModel = SitemapPageViewModel(
+            title: "Test",
+            widgets: [makeTextWidget(widgetID: "w1", label: "One")]
+        )
+        let oldInputs = viewModel.rowInputs
+
+        viewModel.currentPage = makePage(widgets: [
+            makeTextWidget(widgetID: "w1", label: "One"),
+            makeTextWidget(widgetID: "w2", label: "Two")
+        ])
+        viewModel.rebuildRowInputs()
+        let newInputs = viewModel.rowInputs
+
+        let v1Before = viewModel.widgetUpdateVersion(for: oldInputs[0].rowID)
+        let v2Before = 0
+
+        viewModel.bumpWidgetVersions(from: oldInputs, to: newInputs)
+
+        // Count changed — all new rows should get a bump.
+        #expect(viewModel.widgetUpdateVersion(for: newInputs[0].rowID) > v1Before)
+        #expect(viewModel.widgetUpdateVersion(for: newInputs[1].rowID) > v2Before)
+    }
+
+    @Test
+    func bumpWidgetVersionsHandlesRepeatedWidgetIDsIndependently() {
+        let oldWidgets = [
+            makeTextWidget(widgetID: "dup", label: "One"),
+            makeTextWidget(widgetID: "dup", label: "Two")
+        ]
+        let viewModel = SitemapPageViewModel(title: "Test", widgets: oldWidgets)
+        let oldInputs = viewModel.rowInputs
+
+        viewModel.currentPage = makePage(widgets: [
+            makeTextWidget(widgetID: "dup", label: "One"),
+            makeTextWidget(widgetID: "dup", label: "Updated")
+        ])
+        viewModel.rebuildRowInputs()
+        let newInputs = viewModel.rowInputs
+
+        let firstBefore = viewModel.widgetUpdateVersion(for: oldInputs[0].rowID)
+        let secondBefore = viewModel.widgetUpdateVersion(for: oldInputs[1].rowID)
+
+        viewModel.bumpWidgetVersions(from: oldInputs, to: newInputs)
+
+        #expect(viewModel.widgetUpdateVersion(for: newInputs[0].rowID) == firstBefore)
+        #expect(viewModel.widgetUpdateVersion(for: newInputs[1].rowID) > secondBefore)
+    }
+}
+
+// MARK: - Helpers
+
+private extension SitemapPageViewModelDiffingTests {
+    func makeTextWidget(widgetID: String, label: String) -> OpenHABWidget {
+        let widget = OpenHABWidget()
+        widget.widgetId = widgetID
+        widget.type = .text
+        widget.label = label
+        return widget
+    }
+
+    func makePage(widgets: [OpenHABWidget]) -> OpenHABPage {
+        OpenHABPage(pageId: "p1", title: "Test", link: "", leaf: false, widgets: widgets, icon: "")
+    }
+}


### PR DESCRIPTION
## Summary

Fixes scroll hitching reported in #1136, introduced by the SwiftUI sitemap migration in 3.2.x.

**Root cause:** Every long-poll result unconditionally ran `reconcileWidgets` + `copyWidgetProperties` and always reassigned `@Published rowInputs`, broadcasting `objectWillChange` on every cycle even when nothing the list renders changed. Under frequently updating items this produced continuous main-thread churn during inertial scrolling.

**Changes:**

- **Snapshot before mutate** — `updateUI` now maps incoming page data to `SitemapRowInput` values *before* any widget object mutation. If the preview inputs equal the current `rowInputs` and the title is unchanged, the method returns immediately — skipping all reconciliation and every `@Published` write. When `searchText` is active, reconciliation still runs so `currentPage` stays fresh and clearing the filter doesn't reveal stale hidden rows.

- **RowID-keyed widget versioning** — `widgetUpdateVersions` is now keyed by `RowID.rawValue` (pageKey + widgetId + occurrence) instead of bare `widgetId`. This prevents repeated widget IDs on one page from suppressing each other's version advances. `bumpWidgetVersions` increments by full row-identity pairs. `SliderRowView`, `SegmentedRowView`, `SelectionRowView`, and `ImageRowView` pass `input.rowID` to the version lookup; the four affected row-input types (`SliderRowInput`, `SegmentedRowInput`, `SelectionRowInput`, `MediaRowInput`) carry their `rowID`.

- **`rowInputs` equality guard** — `rebuildRowInputs` (called on search-text changes and static init) skips the `@Published` assignment when the computed array equals the current one.

- **Tests** — `SitemapPageViewModelDiffingTests` covers: stable rebuild equality, `objectWillChange` suppression on unchanged data, structure-change rebuild, `bumpWidgetVersions` no-op on identical inputs, per-row version isolation, structure-change full bump, and repeated-widgetId independence (8 cases).

## Test plan

- [ ] Build and run `openHABTestsSwift/SitemapPageViewModelDiffingTests` — all 8 cases pass
- [ ] Manual: open a sitemap with frequently updating items (temperature sensors, power meters), scroll quickly — verify no stutter
- [ ] Manual: use search field, scroll, clear search — verify rows reappear correctly with current state
- [ ] Manual: sliders, segmented controls, selection rows — verify interactive controls still sync with server state
- [ ] Manual: image/chart rows with `refresh` intervals — verify periodic reload still works