### PR TITLE
[codex] Handle invalid inline image data

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Util/StringExtension.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/StringExtension.swift
@@ -199,6 +199,13 @@ public extension String {
         return String(self[separatorRange.upperBound...])
     }
 
+    var dataImageBase64Data: Data? {
+        guard let payload = dataImageBase64Payload else {
+            return nil
+        }
+        return Data(base64Encoded: payload)
+    }
+
     var isNoneIcon: Bool {
         wholeMatch(of: /^(oh:([a-z]+:)?)?none$/) != nil
     }

--- a/OpenHABCore/Tests/OpenHABCoreTests/StringExtensionTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/StringExtensionTests.swift
@@ -54,6 +54,17 @@ struct StringExtensionTests {
         #expect("".dataImageBase64Payload == nil)
     }
 
+    @Test
+    func testDataImageBase64Data() throws {
+        let validPayload = "PHN2Zz48L3N2Zz4="
+        #expect("data:image/svg+xml;base64,\(validPayload)".dataImageBase64Data == Data(base64Encoded: validPayload))
+
+        #expect("data:image/png;base64,%%%".dataImageBase64Data == nil)
+        #expect("data:image/png;base64,".dataImageBase64Data == Data())
+        #expect("data:image/svg+xml,<svg></svg>".dataImageBase64Data == nil)
+        #expect("http://example.com/image.png".dataImageBase64Data == nil)
+    }
+
     // MARK: - doubleValue Tests
 
     @Test func doubleValueWithSimpleInteger() async throws {

--- a/openHAB/UI/SwiftUI/ImageView.swift
+++ b/openHAB/UI/SwiftUI/ImageView.swift
@@ -25,11 +25,17 @@ struct ImageView: View {
     var body: some View {
         if !url.isEmpty {
             switch url {
-            case _ where url.dataImageBase64Payload != nil:
-                let provider = Base64ImageDataProvider(base64String: url.dataImageBase64Payload ?? "", cacheKey: UUID().uuidString)
-                return KFImage(source: .provider(provider))
-                    .setProcessor(OpenHABImageProcessor(svgMaxSize: nil))
-                    .resizable()
+            case _ where url.hasPrefix("data:image"):
+                if let imageData = url.dataImageBase64Data {
+                    let provider = RawImageDataProvider(data: imageData, cacheKey: UUID().uuidString)
+                    return AnyView(
+                        KFImage(source: .provider(provider))
+                            .setProcessor(OpenHABImageProcessor(svgMaxSize: nil))
+                            .resizable()
+                    )
+                } else {
+                    return AnyView(Image("openHABIcon").resizable())
+                }
             case _ where url.hasPrefix("http"):
                 return KFImage(URL(string: url))
                     .setProcessor(OpenHABImageProcessor(svgMaxSize: nil))

--- a/openHAB/UI/SwiftUI/ImageView.swift
+++ b/openHAB/UI/SwiftUI/ImageView.swift
@@ -22,22 +22,21 @@ struct ImageView: View {
 
     @EnvironmentObject var networkTracker: MainActorNetworkTracker
 
+    @ViewBuilder
     var body: some View {
         if !url.isEmpty {
             switch url {
             case _ where url.hasPrefix("data:image"):
                 if let imageData = url.dataImageBase64Data {
                     let provider = RawImageDataProvider(data: imageData, cacheKey: UUID().uuidString)
-                    return AnyView(
-                        KFImage(source: .provider(provider))
-                            .setProcessor(OpenHABImageProcessor(svgMaxSize: nil))
-                            .resizable()
-                    )
+                    KFImage(source: .provider(provider))
+                        .setProcessor(OpenHABImageProcessor(svgMaxSize: nil))
+                        .resizable()
                 } else {
-                    return AnyView(Image("openHABIcon").resizable())
+                    Image("openHABIcon").resizable()
                 }
             case _ where url.hasPrefix("http"):
-                return KFImage(URL(string: url))
+                KFImage(URL(string: url))
                     .setProcessor(OpenHABImageProcessor(svgMaxSize: nil))
                     .resizable()
             default:
@@ -45,13 +44,13 @@ struct ImageView: View {
                     openHABRootUrl: networkTracker.activeConnection?.configuration.url ?? "",
                     path: url.prepare()
                 ).url
-                return KFImage(builtURL)
+                KFImage(builtURL)
                     .setProcessor(OpenHABImageProcessor(svgMaxSize: nil))
                     .resizable()
             }
         } else {
             // This will always fallback to placeholder
-            return KFImage(URL(string: "bundle://openHABIcon")).placeholder { Image("openHABIcon").resizable() }
+            KFImage(URL(string: "bundle://openHABIcon")).placeholder { Image("openHABIcon").resizable() }
         }
     }
 }


### PR DESCRIPTION
## Summary
This change prevents a crash when the app receives an inline `data:image...;base64,...` URL with malformed base64 content.

## What changed
- Added a safe `dataImageBase64Data` helper to decode embedded image payloads without force-unwrapping.
- Updated the SwiftUI image view to use `RawImageDataProvider` only when the base64 payload decodes successfully.
- Made malformed inline image payloads fall back to the bundled placeholder image instead of crashing.
- Added focused tests for valid, invalid, empty, and non-data URI cases.

## Root cause
The inline image path accepted any string that matched `data:image` and contained `;base64,`, then passed the payload to Kingfisher's `Base64ImageDataProvider`. That provider force-unwraps `Data(base64Encoded:)`, so invalid or truncated payloads crash on the main thread.

## Impact
Malformed embedded image data now degrades gracefully to a placeholder image instead of terminating the app.

## Validation
- Attempted: `swift test --package-path OpenHABCore --filter StringExtensionTests`
- Result: not usable as a validation signal in this environment because SwiftPM builds the package for macOS and fails on existing `UIKit` imports in `OpenHABCore` before reaching the updated tests.
