### PR TITLE
Fix inline WebRTC playback for web rows on iPhone

### DIFF
--- a/openHAB/UI/SwiftUI/Rows/WebRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/WebRowView.swift
@@ -50,6 +50,15 @@ private struct WebContainerContent: View {
     }
 }
 
+enum WebRowViewConfigurationFactory {
+    static func make() -> WKWebViewConfiguration {
+        let configuration = WKWebViewConfiguration()
+        configuration.allowsInlineMediaPlayback = true
+        configuration.mediaTypesRequiringUserActionForPlayback = []
+        return configuration
+    }
+}
+
 struct WidgetWebViewContainerView: View {
     let input: MediaRowInput
 
@@ -84,7 +93,7 @@ struct WebRowView: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> WKWebView {
-        let webView = WKWebView()
+        let webView = WKWebView(frame: .zero, configuration: WebRowViewConfigurationFactory.make())
         webView.navigationDelegate = context.coordinator
         return webView
     }

--- a/openHABTestsSwift/WebRowViewConfigurationTests.swift
+++ b/openHABTestsSwift/WebRowViewConfigurationTests.swift
@@ -1,0 +1,25 @@
+// Copyright (c) 2010-2026 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+@testable import openHAB
+import Testing
+import WebKit
+
+@Suite
+struct WebRowViewConfigurationTests {
+    @Test
+    func webRowConfigurationAllowsInlineMutedAutoplay() {
+        let configuration = WebRowViewConfigurationFactory.make()
+
+        #expect(configuration.allowsInlineMediaPlayback)
+        #expect(configuration.mediaTypesRequiringUserActionForPlayback == [])
+    }
+}


### PR DESCRIPTION
## Summary
- apply the same explicit `WKWebViewConfiguration` media playback policy to SwiftUI web rows that the main web controller already uses
- keep inline media playback enabled and remove user-action requirements for playback in the web row path
- add a focused Swift Testing test covering the web row configuration contract

## Testing
- attempted: `xcodebuild test -workspace openHAB.xcworkspace -scheme openHABTestsSwift -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:openHABTestsSwift/WebRowViewConfigurationTests`
- note: the run spent an extended period recompiling the full workspace dependency graph and did not complete within a reasonable turnaround window for this change

Closes #1157