### PR TITLE
Fix main actor warnings in web row configuration

### DIFF
--- a/openHAB/UI/SwiftUI/Rows/WebRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/WebRowView.swift
@@ -50,6 +50,7 @@ private struct WebContainerContent: View {
     }
 }
 
+@MainActor
 enum WebRowViewConfigurationFactory {
     static func make() -> WKWebViewConfiguration {
         let configuration = WKWebViewConfiguration()

--- a/openHABTestsSwift/WebRowViewConfigurationTests.swift
+++ b/openHABTestsSwift/WebRowViewConfigurationTests.swift
@@ -15,6 +15,7 @@ import WebKit
 
 @Suite
 struct WebRowViewConfigurationTests {
+    @MainActor
     @Test
     func webRowConfigurationAllowsInlineMutedAutoplay() {
         let configuration = WebRowViewConfigurationFactory.make()


### PR DESCRIPTION
## Summary
- mark the web row WKWebViewConfiguration factory as @MainActor
- mark the focused configuration test as @MainActor to match WebKit isolation
- address the compiler warnings introduced by the inline playback fix

## Testing
- not run

Follow-up to #1158