### PR TITLE
Fix data race on KingfisherManager and apply per-request auth credentials

### DIFF
--- a/CommonUI/Package.swift
+++ b/CommonUI/Package.swift
@@ -16,14 +16,18 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../OpenHABCore"),
-        .package(url: "https://github.com/apple/swift-numerics", from: "1.0.0")
+        .package(url: "https://github.com/apple/swift-numerics", from: "1.0.0"),
+        .package(url: "https://github.com/onevcat/Kingfisher.git", from: "8.6.1")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: "CommonUI",
-            dependencies: ["OpenHABCore"],
+            dependencies: [
+                "OpenHABCore",
+                .product(name: "Kingfisher", package: "Kingfisher")
+            ],
             swiftSettings: [
                 .enableUpcomingFeature("ExistentialAny"),
                 //                .enableUpcomingFeature("InternalImportsByDefault"),

--- a/CommonUI/Sources/CommonUI/KFImageCredentials.swift
+++ b/CommonUI/Sources/CommonUI/KFImageCredentials.swift
@@ -1,0 +1,22 @@
+// Copyright (c) 2010-2026 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+import Kingfisher
+import OpenHABCore
+
+public extension KFImage {
+    /// Applies the openHAB Basic Auth request modifier when a connection is available.
+    /// When `connection` is nil no modifier is attached and the image loads unauthenticated.
+    func withOpenHABCredentials(for connection: ConnectionInfo?) -> KFImage {
+        guard let connection else { return self }
+        return requestModifier(OpenHABAccessTokenAdapter(connectionConfiguration: connection.configuration))
+    }
+}

--- a/OpenHABCore/Sources/OpenHABCore/Util/NetworkTracker.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/NetworkTracker.swift
@@ -11,7 +11,6 @@
 
 @preconcurrency import Combine
 import Foundation
-import Kingfisher
 import Network
 import OpenAPIRuntime
 import os.log
@@ -499,10 +498,6 @@ public actor NetworkTracker {
             activeConnection = connection
         }
 
-        if let connection {
-            // TODO: suspicious call to "shared" instance with specific connection
-            KingfisherManager.shared.defaultOptions = [.requestModifier(OpenHABAccessTokenAdapter(connectionConfiguration: connection.configuration))]
-        }
     }
 
     private func updateStatus(_ newStatus: NetworkStatus) {

--- a/OpenHABCore/Sources/OpenHABCore/Util/OpenHABAccessTokenAdapter.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/OpenHABAccessTokenAdapter.swift
@@ -53,3 +53,4 @@ extension OpenHABAccessTokenAdapter: ImageDownloadRequestModifier {
         }
     }
 }
+

--- a/openHAB/UI/DrawerView.swift
+++ b/openHAB/UI/DrawerView.swift
@@ -10,6 +10,7 @@
 // SPDX-License-Identifier: EPL-2.0
 
 import Combine
+import CommonUI
 import Kingfisher
 import OpenHABCore
 import os.log
@@ -209,6 +210,7 @@ struct DrawerView: View {
                     icon: sitemap.icon
                 ).url
                 KFImage(url)
+                    .withOpenHABCredentials(for: networkTracker.activeConnection)
                     .placeholder { Image("openHABIcon").resizable() }
                     .resizable()
             }

--- a/openHAB/UI/NotificationsView.swift
+++ b/openHAB/UI/NotificationsView.swift
@@ -10,6 +10,7 @@
 // SPDX-License-Identifier: EPL-2.0
 
 import Combine
+import CommonUI
 import Kingfisher
 import OpenHABCore
 import os.log
@@ -25,6 +26,7 @@ struct NotificationRow: View {
     var body: some View {
         HStack {
             KFImage(iconUrl)
+                .withOpenHABCredentials(for: connection)
                 .placeholder {
                     Image("openHABIcon").resizable()
                 }

--- a/openHAB/UI/SwiftUI/IconURLView.swift
+++ b/openHAB/UI/SwiftUI/IconURLView.swift
@@ -9,6 +9,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0
 
+import CommonUI
 import Kingfisher
 import OpenHABCore
 import os.log
@@ -17,6 +18,7 @@ import SwiftUI
 /// A SwiftUI view that displays widget icons with openHAB-specific styling and caching
 struct IconURLView: View {
     @State var iconURL: URL
+    @ObservedObject private var networkTracker = MainActorNetworkTracker.shared
 
     let size: CGSize
 
@@ -30,6 +32,7 @@ struct IconURLView: View {
                 .frame(width: size.width, height: size.height)
 
             KFImage(iconURL)
+                .withOpenHABCredentials(for: networkTracker.activeConnection)
                 .retry(maxCount: 3, interval: .seconds(5))
                 .resizable()
                 .setProcessor(OpenHABImageProcessor())

--- a/openHAB/UI/SwiftUI/IconView.swift
+++ b/openHAB/UI/SwiftUI/IconView.swift
@@ -10,6 +10,7 @@
 // SPDX-License-Identifier: EPL-2.0
 
 import Combine
+import CommonUI
 import Kingfisher
 import OpenHABCore
 import os.log
@@ -97,6 +98,7 @@ struct IconInputView: View {
 
             if let iconURL {
                 KFImage(iconURL)
+                    .withOpenHABCredentials(for: networkTracker.activeConnection)
                     .retry(maxCount: 3, interval: .seconds(5))
                     .resizable()
                     .setProcessor(OpenHABImageProcessor(iconColor: processorIconColor(for: iconURL)))
@@ -197,6 +199,7 @@ struct IconView: View {
 
             if let iconURL {
                 KFImage(iconURL)
+                    .withOpenHABCredentials(for: networkTracker.activeConnection)
                     .retry(maxCount: 3, interval: .seconds(5))
                     .resizable()
                     .setProcessor(OpenHABImageProcessor(iconColor: processorIconColor(for: iconURL)))

--- a/openHAB/UI/SwiftUI/ImageView.swift
+++ b/openHAB/UI/SwiftUI/ImageView.swift
@@ -10,6 +10,7 @@
 // SPDX-License-Identifier: EPL-2.0
 
 import Combine
+import CommonUI
 import Kingfisher
 import OpenHABCore
 import os.log
@@ -37,6 +38,7 @@ struct ImageView: View {
                 }
             case _ where url.hasPrefix("http"):
                 KFImage(URL(string: url))
+                    .withOpenHABCredentials(for: networkTracker.activeConnection)
                     .setProcessor(OpenHABImageProcessor(svgMaxSize: nil))
                     .resizable()
             default:
@@ -45,6 +47,7 @@ struct ImageView: View {
                     path: url.prepare()
                 ).url
                 KFImage(builtURL)
+                    .withOpenHABCredentials(for: networkTracker.activeConnection)
                     .setProcessor(OpenHABImageProcessor(svgMaxSize: nil))
                     .resizable()
             }

--- a/openHAB/UI/SwiftUI/Rows/ImageRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/ImageRowView.swift
@@ -33,6 +33,7 @@ private struct ImageRowContent: View {
 
     let input: MediaRowInput
     @ObservedObject var viewModel: SitemapPageViewModel
+    @ObservedObject private var networkTracker = MainActorNetworkTracker.shared
     @Environment(\.colorScheme) var colorScheme
     @State private var refreshTimer: Timer?
     @State private var forceRefreshKey = UUID()
@@ -112,6 +113,7 @@ private struct ImageRowContent: View {
         }
 
         KFImage(effectiveChartURL)
+            .withOpenHABCredentials(for: networkTracker.activeConnection)
             .cacheMemoryOnly(false)
             .cacheOriginalImage(true)
             .fade(duration: 0)
@@ -150,6 +152,7 @@ private struct ImageRowContent: View {
             }
             let provider = RawImageDataProvider(data: data, cacheKey: cacheKey)
             KFImage(source: .provider(provider))
+                .withOpenHABCredentials(for: networkTracker.activeConnection)
                 .setProcessor(OpenHABImageProcessor(svgMaxSize: nil))
                 .resizable()
                 .aspectRatio(contentMode: .fit)
@@ -157,6 +160,7 @@ private struct ImageRowContent: View {
                 .clipShape(.rect(cornerRadius: 8))
         case let .link(url):
             KFImage(url)
+                .withOpenHABCredentials(for: networkTracker.activeConnection)
                 .setProcessor(OpenHABImageProcessor(svgMaxSize: nil))
                 .resizable()
                 .cacheMemoryOnly(!shouldCache)

--- a/openHABWatch/Views/Rows/ImageRow.swift
+++ b/openHABWatch/Views/Rows/ImageRow.swift
@@ -62,6 +62,7 @@ struct ImageRow: View, Equatable {
     let refresh: Int // Refresh interval in milliseconds, 0 means no refresh
 
     @StateObject private var refreshTimer = ImageRefreshTimer()
+    @ObservedObject private var networkTracker = MainActorNetworkTracker.shared
 
     // For refreshing images, append a query parameter to bust the cache
     private var displayUrl: URL? {
@@ -78,6 +79,7 @@ struct ImageRow: View, Equatable {
 
     var body: some View {
         KFImage.url(displayUrl)
+            .withOpenHABCredentials(for: networkTracker.activeConnection)
             .cacheMemoryOnly(refresh > 0)
             .loadDiskFileSynchronously()
             .resizable()

--- a/openHABWatch/Views/Utils/WatchIconView.swift
+++ b/openHABWatch/Views/Utils/WatchIconView.swift
@@ -9,6 +9,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0
 
+import CommonUI
 import Kingfisher
 import OpenHABCore
 import os.log
@@ -29,6 +30,7 @@ struct WatchIconView: View {
     @ObservedObject var settings = AppSettings.shared
     @ObservedObject private var networkTracker = MainActorNetworkTracker.shared
     @State private var lastResolvedIconURL: URL?
+    @State private var lastResolvedConnection: ConnectionInfo?
     @State private var keepLastResolvedIconURLUntil: Date = .distantPast
 
     private let iconURLGraceSeconds: TimeInterval = 3
@@ -49,12 +51,18 @@ struct WatchIconView: View {
     }
 
     // During a transient connection handover activeConnection can briefly be nil.
-    // Hold the last successfully resolved URL for a short grace period so icons
-    // don't flash blank between reconnects.
+    // Hold the last successfully resolved URL and connection for a short grace period
+    // so icons don't flash blank between reconnects, and retained auth carries over.
     private var displayIconURL: URL? {
         if let url = iconURL { return url }
         guard Date() <= keepLastResolvedIconURLUntil else { return nil }
         return lastResolvedIconURL
+    }
+
+    private var displayConnection: ConnectionInfo? {
+        if let connection = networkTracker.activeConnection { return connection }
+        guard Date() <= keepLastResolvedIconURLUntil else { return nil }
+        return lastResolvedConnection
     }
 
     var body: some View {
@@ -63,6 +71,7 @@ struct WatchIconView: View {
                 // Only apply color preprocessing for non-iconify icons
                 let processorIconColor = iconURL.host == "api.iconify.design" ? nil : model.iconColorHex
                 KFImage.url(iconURL)
+                    .withOpenHABCredentials(for: displayConnection)
                     .onFailure { _ in
                         Logger.rowViews.debug("Failed to load image : \(iconURL.absoluteString)")
                     }
@@ -92,6 +101,7 @@ struct WatchIconView: View {
         .onChange(of: iconURL) { _, newURL in
             if let newURL {
                 lastResolvedIconURL = newURL
+                lastResolvedConnection = networkTracker.activeConnection
                 keepLastResolvedIconURLUntil = .distantPast
             } else if lastResolvedIconURL != nil {
                 keepLastResolvedIconURLUntil = Date().addingTimeInterval(iconURLGraceSeconds)


### PR DESCRIPTION
## Summary

- Removes the data race caused by mutating `KingfisherManager.shared.defaultOptions` from within the `NetworkTracker` actor (a `@MainActor`-isolated object being written across isolation boundaries)
- Replaces the global credential mutation with a per-request `KFImage.withOpenHABCredentials(for:)` extension applied at every `KFImage` call site across iOS and watchOS
- Moves the `KFImage` extension from `OpenHABCore` into `CommonUI` to respect the Core/UI module boundary; adds Kingfisher as a `CommonUI` dependency
- Extends `WatchIconView` grace-period logic to retain the last active connection alongside the last resolved icon URL, preventing auth from dropping during brief reconnects
-   Fixes the NetworkTracker.swift          // TODO: suspicious call to "shared" instance with specific connection


## Test plan

- [ ] Icons and images load correctly on both iOS and watchOS when connected to a password-protected openHAB instance
- [ ] Sitemap icons, image widgets, notification icons, and drawer sitemap icons all authenticate correctly
- [ ] No data race warnings in the Thread Sanitizer for Kingfisher image loading
- [ ] Icons do not flash blank during brief network reconnects on watchOS