### PR TITLE
[codex] Use video item state URL before default

### DIFF
--- a/openHAB/UI/SwiftUI/WidgetRowInputs.swift
+++ b/openHAB/UI/SwiftUI/WidgetRowInputs.swift
@@ -9,6 +9,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0
 
+import Foundation
 import OpenHABCore
 
 protocol RowWithIconInput {
@@ -427,6 +428,7 @@ struct MediaRowInput: Equatable {
         let coordinate = widget.coordinate
         let hasValidCoordinate = (-90.0 ... 90.0).contains(coordinate.latitude)
             && (-180.0 ... 180.0).contains(coordinate.longitude)
+        let url = effectiveURL(for: widget)
 
         return MediaRowInput(
             widgetId: widget.widgetId,
@@ -437,13 +439,31 @@ struct MediaRowInput: Equatable {
             valueColor: widget.valuecolor,
             readOnly: widget.readOnly ?? false,
             refresh: widget.refresh,
-            url: widget.url,
+            url: url,
             encoding: widget.encoding,
             labelSourceRawValue: widget.labelSource.rawValue,
             preferredRowHeight: widget.preferredRowHeight.map(Double.init),
             coordinateLatitude: hasValidCoordinate ? coordinate.latitude : nil,
             coordinateLongitude: hasValidCoordinate ? coordinate.longitude : nil
         )
+    }
+
+    private static func effectiveURL(for widget: OpenHABWidget) -> String {
+        guard widget.renderingKind == .video,
+              let itemState = widget.item?.state?.trimmingCharacters(in: .whitespacesAndNewlines),
+              isAbsoluteURL(itemState) else {
+            return widget.url
+        }
+
+        return itemState
+    }
+
+    private static func isAbsoluteURL(_ value: String) -> Bool {
+        guard let url = URL(string: value),
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return false
+        }
+        return components.scheme != nil && (components.host != nil || components.path.hasPrefix("/"))
     }
 }
 

--- a/openHABTestsSwift/SitemapRowInputMapperTests.swift
+++ b/openHABTestsSwift/SitemapRowInputMapperTests.swift
@@ -61,6 +61,30 @@ struct SitemapRowInputMapperTests {
         #expect(mappedRowID == rowID)
         #expect(input.widgetId == widget.widgetId)
     }
+
+    @Test
+    func videoWidgetUsesItemStateURLBeforeConfiguredURL() {
+        let widget = makeVideoWidget(
+            widgetID: "video",
+            url: "http://default.example.invalid/video.m3u8",
+            itemState: "http://camera.example.invalid/live.m3u8"
+        )
+        let input = MediaRowInput.from(widget: widget)
+
+        #expect(input.url == "http://camera.example.invalid/live.m3u8")
+    }
+
+    @Test
+    func videoWidgetFallsBackToConfiguredURLWhenItemStateIsNotURL() {
+        let widget = makeVideoWidget(
+            widgetID: "video",
+            url: "http://default.example.invalid/video.m3u8",
+            itemState: "OFF"
+        )
+        let input = MediaRowInput.from(widget: widget)
+
+        #expect(input.url == "http://default.example.invalid/video.m3u8")
+    }
 }
 
 private extension SitemapRowInputMapperTests {
@@ -178,6 +202,15 @@ private extension SitemapRowInputMapperTests {
         let widget = OpenHABWidget()
         widget.widgetId = widgetID
         widget.type = .frame
+        return widget
+    }
+
+    func makeVideoWidget(widgetID: String, url: String, itemState: String) -> OpenHABWidget {
+        let widget = OpenHABWidget()
+        widget.widgetId = widgetID
+        widget.type = .video
+        widget.url = url
+        widget.item = makeItem(name: "VideoItem", type: "String", state: itemState)
         return widget
     }
 }


### PR DESCRIPTION
## Summary

Fixes sitemap Video rows so a linked String item state URL takes precedence over the configured `url` fallback, matching the openHAB sitemap documentation.

## Root Cause

The SwiftUI media row mapper always passed `widget.url` through to `VideoRowView`, so Video widgets ignored an associated String item whose state contained the current stream URL.

## Changes

- Resolve an effective media URL for Video widgets during row input mapping.
- Use the item state only when it parses as an absolute URL.
- Keep the configured `url` as the fallback when the item is absent or its state is not a URL.
- Add focused Swift Testing coverage for both override and fallback behavior.

## Validation

```sh
xcodebuild test -workspace openHAB.xcworkspace -scheme openHABTestsSwift -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:openHABTestsSwift/SitemapRowInputMapperTests
```

Result: `TEST SUCCEEDED`.